### PR TITLE
Fix python doc links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+## 0.9.0
+
+Initial release of Alloy. This library is intended to eventually replace the Tenant Security Client libraries, and include additional functionality. Right now this includes:
+
+- our standard (probabilistic, fully random) encryption
+- deterministic encryption 
+- Cloaked AI vector encryption
+
+All three of these support standalone and SaaS Shield modes in this SDK.
+
+Notable features coming soon:
+- SaaS Shield security events
+- backwards compatibility with TSC libraries
+- batch APIs
+- rekey and rotate functionality
+
+### Compatibility
+
+Requires TSP 4.12.0+. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ironcore Alloy SDK is designed to be a single SDK for all the different IronCore
 
 - [Java](http://todo.com)
 - [Kotlin](http://todo.com)
-- [Python](http://todo.com)
+- [Python](https://pypi.org/project/ironcore-alloy)
 - [Rust](http://todo.com)
 
 This SDK was written in Rust and is using [uniffi](https://github.com/mozilla/uniffi-rs) to generate the foreign language bindings. If your language is not listed above, feel free to open an issue and we can take a look!

--- a/python/ironcore-alloy/README.md
+++ b/python/ironcore-alloy/README.md
@@ -3,7 +3,7 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/ironcore-alloy.svg)](https://pypi.org/project/ironcore-alloy)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ironcore-alloy.svg)](https://pypi.org/project/ironcore-alloy)
 
-Python bindings to the IronCore Labs Alloy SDK. Generated library API documentation hopefully incoming.
+Python bindings to the IronCore Labs Alloy SDK. Python API documentation is available [here](https://ironcore-alloy.readthedocs.io). General documentation of the various products and broader information about how to use the SDK is available [here](https://docs.ironcorelabs.com).
 
 - [Installation](#installation)
 - [License](#license)


### PR DESCRIPTION
The `python/README` is what shows up on the pypi package page.