### PR TITLE
Remove IronCoreDocumentsError, consume new ironcore-documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,8 +1096,8 @@ dependencies = [
 
 [[package]]
 name = "ironcore-documents"
-version = "0.1.0-pre.8"
-source = "git+https://github.com/IronCoreLabs/ironcore-documents.git?rev=76e2e20fe97e15e27f3d6146562f054144977103#76e2e20fe97e15e27f3d6146562f054144977103"
+version = "0.1.0-pre.11"
+source = "git+https://github.com/IronCoreLabs/ironcore-documents.git?rev=5eaa74f0eb19f69ed28b37228036f1d360b43dc6#5eaa74f0eb19f69ed28b37228036f1d360b43dc6"
 dependencies = [
  "aes-gcm",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ base64_type = { git = "https://github.com/IronCoreLabs/base64_type", version = "
 bytes = { version = "1.4.0", features = ["serde"] }
 futures = "0.3.29"
 hmac = { version = "0.12.1", features = ["std"] }
-ironcore-documents = { git = "https://github.com/IronCoreLabs/ironcore-documents.git", rev = "76e2e20fe97e15e27f3d6146562f054144977103" }
+ironcore-documents = { git = "https://github.com/IronCoreLabs/ironcore-documents.git", rev = "5eaa74f0eb19f69ed28b37228036f1d360b43dc6" }
 itertools = "0.11"
 ndarray = "0.15.6"
 ndarray-rand = "0.14.0"

--- a/src/deterministic.rs
+++ b/src/deterministic.rs
@@ -172,9 +172,12 @@ fn deterministic_decrypt_core(
     associated_data: &[u8],
 ) -> Result<Vec<u8>, AlloyError> {
     let mut cipher = Aes256Siv::new(&key.into());
-    cipher
-        .decrypt([associated_data], ciphertext)
-        .map_err(|e| AlloyError::DecryptError(e.to_string()))
+    cipher.decrypt([associated_data], ciphertext).map_err(|_| {
+        AlloyError::DecryptError(
+            "Failed deterministic decryption. Ensure the data and tenant ID are correct"
+                .to_string(),
+        )
+    })
 }
 
 /// Returns `true` if the key IDs and tenant IDs are identical, otherwise `false`.

--- a/src/saas_shield/standard.rs
+++ b/src/saas_shield/standard.rs
@@ -319,7 +319,10 @@ pub fn generate_cmk_v4_doc_and_sign(
         })
         .collect();
 
-    Ok(ironcore_documents::create_signed_proto(edek_wrappers, dek))
+    Ok(ironcore_documents::v4::aes::create_signed_proto(
+        edek_wrappers,
+        dek,
+    ))
 }
 
 #[cfg(test)]

--- a/src/standalone/standard_attached.rs
+++ b/src/standalone/standard_attached.rs
@@ -141,7 +141,7 @@ mod test {
             .decrypt(EncryptedAttachedDocument(encrypted.to_vec()), &metadata)
             .await
             .unwrap_err();
-        assert_eq!(err, AlloyError::DecryptError("aead::Error".to_string()))
+        assert!(matches!(err, AlloyError::DecryptError(_)))
     }
 
     #[tokio::test]

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -151,7 +151,7 @@ pub(crate) fn verify_sig(
     aes_dek: EncryptionKey,
     document: &icl_header_v4::V4DocumentHeader,
 ) -> Result<(), AlloyError> {
-    if ironcore_documents::verify_signature(aes_dek, document) {
+    if ironcore_documents::v5::aes::verify_signature(aes_dek, document) {
         Ok(())
     } else {
         Err(AlloyError::DecryptError(


### PR DESCRIPTION
IronCoreDocumentsError isn't meaningful to a caller, so map it to something more helpful. 
More changes will come with #5 to make errors more match-able.