### PR TITLE
Rework AlloyError to be more useful in generated languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "approx"
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.12.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0fc7dcf8bd4ead96b1d36b41df47c14beedf7b0301fc543d8f2384e66a2ec0"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -186,9 +186,9 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "askama_parser"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c268a96e01a4c47c8c5c2472aaa570707e006a875ea63e819f75474ceedaf7b4"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
 dependencies = [
  "nom",
 ]
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64-serde"
@@ -262,8 +262,8 @@ dependencies = [
 
 [[package]]
 name = "base64_type"
-version = "0.1.2"
-source = "git+https://github.com/IronCoreLabs/base64_type#7a72b6ab4dbc6564903e77320619e020ac7ed859"
+version = "0.1.2-pre.1"
+source = "git+https://github.com/IronCoreLabs/base64_type#da678f2e28edf676b690221bb1994ec5728e7a19"
 dependencies = [
  "base64",
  "base64-serde",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "basic-toml"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
+checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
 dependencies = [
  "serde",
 ]
@@ -321,9 +321,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "block-buffer"
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
 dependencies = [
  "serde",
 ]
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -523,9 +523,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -570,35 +570,28 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.16"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.17"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -703,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -718,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -728,15 +721,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -745,15 +738,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -762,21 +755,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -802,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -846,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -889,9 +882,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -916,11 +909,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -959,9 +952,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -974,7 +967,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1101,13 +1094,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1145,9 +1138,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1160,9 +1153,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libm"
@@ -1172,9 +1165,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -1194,18 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mime"
@@ -1324,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -1433,9 +1417,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -1448,7 +1432,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "rand",
@@ -1520,9 +1504,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1584,9 +1568,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -1594,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1642,9 +1626,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "base64",
  "bytes",
@@ -1717,11 +1701,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1818,27 +1802,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1847,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -1902,16 +1886,6 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -1952,9 +1926,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,15 +1958,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2008,18 +1982,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2053,9 +2027,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2063,7 +2037,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -2166,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -2206,7 +2180,7 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 [[package]]
 name = "uniffi"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "anyhow",
  "camino",
@@ -2219,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "anyhow",
  "askama",
@@ -2243,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "anyhow",
  "camino",
@@ -2253,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "quote",
  "syn",
@@ -2262,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2278,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "bincode",
  "camino",
@@ -2296,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2307,7 +2281,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "anyhow",
  "camino",
@@ -2319,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.25.3"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -2409,9 +2383,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2419,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -2434,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2446,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2456,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2469,15 +2443,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2492,7 +2466,7 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#5588e5b2fe478f87cadc339aea5affd08f73576d"
+source = "git+https://github.com/bendk/uniffi-rs.git?branch=foreign-trait-interfaces-opt-in#e70164e10c123104864347329cd926ce32155fa9"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ aes-gcm = { version = "0.10" }
 aes-siv = { version = "0.7" }
 async-trait = "0.1.74"
 base64 = "0.21"
-base64_type = { git = "https://github.com/IronCoreLabs/base64_type", version = "0.1.0" }
+base64_type = { git = "https://github.com/IronCoreLabs/base64_type", version = "0.1.2-pre.1" }
 bytes = { version = "1.4.0", features = ["serde"] }
 convert_case = "0.6.0"
 futures = "0.3.29"
@@ -58,7 +58,7 @@ z85 = "3.0.5"
 [dev-dependencies]
 approx = "0.5.1"
 ascii85 = "0.2.1"
-assertables = "7.0.1" 
+assertables = "7.0.1"
 base64 = "0.21.5"
 base85 = "2.0.0"
 camino = "1.1"

--- a/python/ironcore-alloy/tests/test_ironcore_alloy.py
+++ b/python/ironcore-alloy/tests/test_ironcore_alloy.py
@@ -214,6 +214,18 @@ class TestIroncoreAlloy:
         expected = b"My data"
         assert decrypted.plaintext_field == expected
 
+    @pytest.mark.asyncio
+    async def test_rotate_deterministic_failures(self):
+        field = EncryptedField(
+            base64.b64decode(b"AAAAAoAA4hdzU2eh2aeCoUSq6NQiWYczhmQQNak="), "wrong_path", "wrong_path"
+        )
+        fields = {"doc": field}
+        metadata = AlloyMetadata.new_simple("tenant")
+        rotated = await self.sdk.deterministic().rotate_fields(fields, metadata, "tenant2")
+        assert len(rotated.successes) == 0
+        assert len(rotated.failures) == 1
+        assert "Provided secret path `wrong_path` does not exist" in rotated.failures["doc"].msg 
+
     @pytest.mark.skip(reason="need seeded client")
     @pytest.mark.asyncio
     async def test_encrypt_probabilistic_metadata(self):

--- a/python/ironcore-alloy/tests/test_ironcore_alloy.py
+++ b/python/ironcore-alloy/tests/test_ironcore_alloy.py
@@ -29,6 +29,9 @@ class TestIroncoreAlloy:
     )
     sdk = Standalone(config)
 
+    # Tests using this are skipped by default. Unskip them as needed
+    integration_sdk = SaasShield(SaasShieldConfiguration("http://localhost:32804", "0WUaXesNgbTAuLwn", False, 1.1))
+
     def test_floating_point_math(self):
         pass
 
@@ -311,3 +314,19 @@ class TestIroncoreAlloy:
         importlib.reload(ironcore_alloy)
         # if it can still create a Standalone object through the FFI we'll assume it's still good after the reload
         sdk = Standalone(self.config)
+
+    @pytest.mark.skip(reason="Integration test. Unskip as desired")
+    @pytest.mark.asyncio
+    async def test_unknown_tenant(self):
+        with pytest.raises(AlloyError.TspError) as tsp_error:
+            metadata = AlloyMetadata.new_simple("fake_tenant")
+            await self.integration_sdk.vector().encrypt(PlaintextVector([1, 2, 4], "", ""), metadata)
+        assert "Tenant either doesn't exist" in tsp_error.value.msg
+
+    @pytest.mark.asyncio
+    async def test_bad_request(self):
+        with pytest.raises(AlloyError.RequestError) as request_error:
+            bad_integration_sdk = SaasShield(SaasShieldConfiguration("http://bad-url", "0WUaXesNgbTAuLwn", False, 1.1))
+            metadata = AlloyMetadata.new_simple("fake_tenant")
+            await bad_integration_sdk.vector().encrypt(PlaintextVector([1, 2, 4], "", ""), metadata)
+        assert "error sending request for url" in str(request_error.value.msg)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,7 +26,7 @@ pub enum AlloyError {
     SerdeJsonError { msg: String },
     /// Error directly from the TSP
     TspError {
-        err: TenantSecurityProxyError,
+        error: TenantSecurityProxyError,
         http_code: u16,
         tsp_code: u16,
         msg: String,
@@ -46,13 +46,13 @@ impl std::fmt::Display for AlloyError {
             AlloyError::RequestError { msg } => write!(f, "Request error: '{msg}'"),
             AlloyError::SerdeJsonError { msg } => write!(f, "Serde JSON error: '{msg}'"),
             AlloyError::TspError {
-                err,
+                error,
                 tsp_code,
                 http_code,
                 msg,
             } => write!(
                 f,
-                "TSP error variant: '{err}', HTTP code: {http_code}, TSP code: {tsp_code}, Message: {msg}"
+                "TSP error variant: '{error}', HTTP code: {http_code}, TSP code: {tsp_code}, Message: {msg}"
             ),
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,7 +24,8 @@ pub enum AlloyError {
     RequestError { msg: String },
     /// Error converting request data to JSON
     SerdeJsonError { msg: String },
-    /// Error directly from the TSP
+    /// Error directly from the TSP. See https://ironcorelabs.com/docs/saas-shield/tenant-security-proxy/errors/
+    /// for details about these error codes.
     TspError {
         error: TenantSecurityProxyError,
         http_code: u16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ pub(crate) mod alloy_client_trait {
             if edek_type == expected_edek_type && payload_type == expected_payload_type {
                 Ok((key_id, remaining_bytes))
             } else {
-                Err(AlloyError::InvalidInput{msg: 
+                Err(AlloyError::InvalidInput{ msg:
                     format!("The data indicated that this was not a {expected_edek_type} {expected_payload_type} wrapped value. Found: {edek_type}, {payload_type}"),
             })
             }
@@ -318,9 +318,9 @@ impl Secret {
     #[uniffi::constructor]
     pub fn new(secret: Vec<u8>) -> Result<Arc<Self>, AlloyError> {
         if secret.len() < 32 {
-            Err(AlloyError::InvalidConfiguration{msg: 
-                "Secrets must be at least 32 cryptographically random bytes.".to_string(),
-        })
+            Err(AlloyError::InvalidConfiguration {
+                msg: "Secrets must be at least 32 cryptographically random bytes.".to_string(),
+            })
         } else {
             Ok(Arc::new(Self { secret }))
         }

--- a/src/saas_shield/config.rs
+++ b/src/saas_shield/config.rs
@@ -29,8 +29,7 @@ impl SaasShieldConfiguration {
             approximation_factor,
             tenant_security_client: Arc::new(TenantSecurityClient::new(
                 tsp_uri,
-                ApiKey::try_from(api_key)
-                    .map_err(|e| AlloyError::InvalidConfiguration(format!("{}", e)))?,
+                ApiKey::try_from(api_key)?,
                 reqwest_client,
             )),
         }))

--- a/src/saas_shield/deterministic.rs
+++ b/src/saas_shield/deterministic.rs
@@ -104,10 +104,10 @@ impl DeterministicFieldOps for SaasShieldDeterministicClient {
             DeriveKeyChoice::Specific(key_id),
         )?;
         if derived_key.tenant_secret_id.0 != key_id.0 {
-            Err(AlloyError::InvalidKey(
+            Err(AlloyError::InvalidKey{msg: 
                     "The key ID in the document header and on the key derived for decryption did not match"
                         .to_string(),
-                ))
+        })
         } else {
             decrypt_internal(
                 DeterministicEncryptionKey(derived_key.derived_key.0.clone()),
@@ -143,9 +143,10 @@ impl DeterministicFieldOps for SaasShieldDeterministicClient {
                 let keys = all_keys
                     .get(&plaintext_field.secret_path)
                     .and_then(|deriv| deriv.get(&plaintext_field.derivation_path))
-                    .ok_or(AlloyError::TenantSecurityError(
-                        "Failed to derive keys for provided path using the TSP.".to_string(),
-                    ))?;
+                    .ok_or(AlloyError::RequestError {
+                        msg: "Failed to derive keys for provided path using the TSP.".to_string(),
+                    },
+                )?;
                 keys.iter()
                     .map(|derived_key| {
                         let key_id_header =

--- a/src/saas_shield/deterministic.rs
+++ b/src/saas_shield/deterministic.rs
@@ -104,7 +104,7 @@ impl DeterministicFieldOps for SaasShieldDeterministicClient {
             DeriveKeyChoice::Specific(key_id),
         )?;
         if derived_key.tenant_secret_id.0 != key_id.0 {
-            Err(AlloyError::InvalidKey{msg: 
+            Err(AlloyError::InvalidKey{ msg:
                     "The key ID in the document header and on the key derived for decryption did not match"
                         .to_string(),
         })
@@ -145,8 +145,7 @@ impl DeterministicFieldOps for SaasShieldDeterministicClient {
                     .and_then(|deriv| deriv.get(&plaintext_field.derivation_path))
                     .ok_or(AlloyError::RequestError {
                         msg: "Failed to derive keys for provided path using the TSP.".to_string(),
-                    },
-                )?;
+                    })?;
                 keys.iter()
                     .map(|derived_key| {
                         let key_id_header =
@@ -274,10 +273,9 @@ impl SaasShieldSecurityEventOps for SaasShieldDeterministicClient {
         event_time_millis: Option<i64>,
     ) -> Result<(), AlloyError> {
         let request_metadata = (metadata.clone(), event_time_millis).try_into()?;
-        Ok(self
-            .tenant_security_client
+        self.tenant_security_client
             .log_security_event(&event, &request_metadata)
-            .await?)
+            .await
     }
 }
 

--- a/src/saas_shield/mod.rs
+++ b/src/saas_shield/mod.rs
@@ -129,9 +129,10 @@ impl CustomEvent {
         let regex =
             regex::Regex::new("^[A-Z_]+$").expect("Regex compilation is a development error");
         if !regex.is_match(event_name) || event_name.starts_with('_') {
-            Err(AlloyError::InvalidInput(
-                "CustomEvents must be screaming snake case and cannot start with _".to_string(),
-            ))
+            Err(AlloyError::InvalidInput {
+                msg: "CustomEvents must be screaming snake case and cannot start with _"
+                    .to_string(),
+            })
         } else {
             Ok(CustomEvent {
                 event_name: event_name.to_string(),
@@ -212,9 +213,9 @@ fn derived_key_to_vector_encryption_key(
     derived_key: &DerivedKey,
 ) -> Result<(KeyId, VectorEncryptionKey), AlloyError> {
     let key = if derived_key.derived_key.len() < 35 {
-        Err(AlloyError::TenantSecurityError(
-            "Derivation didn't return enough bytes. HMAC-SHA512 should always return 64 bytes, so the TSP is misbehaving.".to_string(),
-        ))
+        Err(AlloyError::RequestError {msg:
+            "Derivation didn't return enough bytes. HMAC-SHA512 should always return 64 bytes, so the TSP is misbehaving.".to_string()
+        })
     } else {
         let key_bytes = &derived_key.derived_key.0[..];
         Ok(VectorEncryptionKey::unsafe_bytes_to_key(key_bytes))
@@ -392,16 +393,18 @@ mod test {
     fn test_custom_create() {
         assert_eq!(
             CustomEvent::create("_THIS_FAILS").unwrap_err(),
-            AlloyError::InvalidInput(
-                "CustomEvents must be screaming snake case and cannot start with _".to_string()
-            )
+            AlloyError::InvalidInput {
+                msg: "CustomEvents must be screaming snake case and cannot start with _"
+                    .to_string()
+            }
         );
 
         assert_eq!(
             CustomEvent::create("thisAlso").unwrap_err(),
-            AlloyError::InvalidInput(
-                "CustomEvents must be screaming snake case and cannot start with _".to_string()
-            )
+            AlloyError::InvalidInput {
+                msg: "CustomEvents must be screaming snake case and cannot start with _"
+                    .to_string()
+            }
         );
     }
 }

--- a/src/saas_shield/standard.rs
+++ b/src/saas_shield/standard.rs
@@ -154,7 +154,7 @@ impl SaasShieldStandardClient {
                     let v4_document_header = v4_proto_from_bytes(remaining_bytes)?;
                     Ok(EdekParts::V5(key_id, v4_document_header))
                 } else {
-                    Err(AlloyError::InvalidInput{msg: 
+                    Err(AlloyError::InvalidInput{ msg:
                 format!("The data indicated that this was not a {expected_edek_type} {expected_payload_type} wrapped value. Found: {edek_type}, {payload_type}"),
                 })
                 }
@@ -290,10 +290,9 @@ impl SaasShieldSecurityEventOps for SaasShieldStandardClient {
         event_time_millis: Option<i64>,
     ) -> Result<(), AlloyError> {
         let request_metadata = (metadata.clone(), event_time_millis).try_into()?;
-        Ok(self
-            .tenant_security_client
+        self.tenant_security_client
             .log_security_event(&event, &request_metadata)
-            .await?)
+            .await
     }
 }
 
@@ -337,9 +336,9 @@ fn fix_encrypted_dek(
 }
 
 fn tsc_dek_to_encryption_key(dek: Vec<u8>) -> Result<EncryptionKey, AlloyError> {
-    let bytes: [u8; 32] = dek
-        .try_into()
-        .map_err(|_| AlloyError::InvalidKey { msg: "Invalid DEK".to_string() })?;
+    let bytes: [u8; 32] = dek.try_into().map_err(|_| AlloyError::InvalidKey {
+        msg: "Invalid DEK".to_string(),
+    })?;
     Ok(EncryptionKey(bytes))
 }
 

--- a/src/saas_shield/vector.rs
+++ b/src/saas_shield/vector.rs
@@ -42,11 +42,12 @@ impl SaasShieldVectorClient {
         key_id: KeyId,
         plaintext_vector: PlaintextVector,
     ) -> Result<EncryptedVector, AlloyError> {
-        let approximation_factor = self.approximation_factor.ok_or_else(|| {
-            AlloyError::InvalidConfiguration{msg: 
-                "`approximation_factor` was not set in the vector configuration.".to_string(),
-            }
-        })?;
+        let approximation_factor =
+            self.approximation_factor
+                .ok_or_else(|| AlloyError::InvalidConfiguration {
+                    msg: "`approximation_factor` was not set in the vector configuration."
+                        .to_string(),
+                })?;
         encrypt_internal(
             approximation_factor,
             key,
@@ -69,10 +70,9 @@ impl SaasShieldSecurityEventOps for SaasShieldVectorClient {
         event_time_millis: Option<i64>,
     ) -> Result<(), AlloyError> {
         let request_metadata = (metadata.clone(), event_time_millis).try_into()?;
-        Ok(self
-            .tenant_security_client
+        self.tenant_security_client
             .log_security_event(&event, &request_metadata)
-            .await?)
+            .await
     }
 }
 
@@ -125,11 +125,12 @@ impl VectorOps for SaasShieldVectorClient {
         encrypted_vector: EncryptedVector,
         metadata: &AlloyMetadata,
     ) -> Result<PlaintextVector, AlloyError> {
-        let approximation_factor = self.approximation_factor.ok_or_else(|| {
-            AlloyError::InvalidConfiguration{msg:
-                "`approximation_factor` was not set in the vector configuration.".to_string(),
-            }
-        })?;
+        let approximation_factor =
+            self.approximation_factor
+                .ok_or_else(|| AlloyError::InvalidConfiguration {
+                    msg: "`approximation_factor` was not set in the vector configuration."
+                        .to_string(),
+                })?;
         let (key_id, icl_metadata_bytes) =
             Self::decompose_key_id_header(encrypted_vector.paired_icl_info.clone())?;
 
@@ -154,7 +155,7 @@ impl VectorOps for SaasShieldVectorClient {
         )?;
         let (derived_key_id, key) = derived_key_to_vector_encryption_key(derived_key)?;
         if derived_key_id != key_id {
-            Err(AlloyError::InvalidKey{msg: 
+            Err(AlloyError::InvalidKey{ msg:
                     "The key ID in the paired ICL info and on the key derived for decryption did not match"
                         .to_string(),
         })
@@ -194,10 +195,8 @@ impl VectorOps for SaasShieldVectorClient {
                     .get(&plaintext_vector.secret_path)
                     .and_then(|deriv| deriv.get(&plaintext_vector.derivation_path))
                     .ok_or(AlloyError::RequestError {
-                            msg: "Failed to derive keys for provided path using the TSP."
-                                .to_string(),
-                        },
-                    )?;
+                        msg: "Failed to derive keys for provided path using the TSP.".to_string(),
+                    })?;
                 keys.iter()
                     .map(|derived_key| {
                         let (key_id, key) = derived_key_to_vector_encryption_key(derived_key)?;

--- a/src/standalone/config.rs
+++ b/src/standalone/config.rs
@@ -39,9 +39,9 @@ impl StandardSecrets {
         let mut internal_secrets = HashMap::new();
 
         if secrets.iter().any(|secret| secret.id == 0) {
-            return Err(AlloyError::InvalidKey(
-                "Secret ids must be greater than 0".to_string(),
-            ));
+            return Err(AlloyError::InvalidKey {
+                msg: "Secret ids must be greater than 0".to_string(),
+            });
         }
 
         for standalone_secret in secrets.into_iter() {
@@ -52,19 +52,21 @@ impl StandardSecrets {
                 )
                 .is_some()
             {
-                return Err(AlloyError::InvalidKey(format!(
-                    "Duplicate secret id encountered while initializing Standalone mode: {}",
-                    standalone_secret.id
-                )));
+                return Err(AlloyError::InvalidKey {
+                    msg: format!(
+                        "Duplicate secret id encountered while initializing Standalone mode: {}",
+                        standalone_secret.id
+                    ),
+                });
             }
         }
 
         // check that the provided primary does in fact exist
         if let Some(id) = primary_secret_id {
             if internal_secrets.get(&(id as u32)).is_none() {
-                return Err(AlloyError::InvalidKey(format!(
-                    "Primary secret id not found in provided secrets: {id}"
-                )));
+                return Err(AlloyError::InvalidKey {
+                    msg: format!("Primary secret id not found in provided secrets: {id}"),
+                });
             }
         }
 
@@ -93,9 +95,9 @@ impl RotatableSecret {
         in_rotation_secret: Option<Arc<StandaloneSecret>>,
     ) -> Result<Arc<Self>, AlloyError> {
         if current_secret.is_none() && in_rotation_secret.is_none() {
-            Err(AlloyError::InvalidKey(
-                "Cannot create a RotatingSecret with no secrets.".to_string(),
-            ))
+            Err(AlloyError::InvalidKey {
+                msg: "Cannot create a RotatingSecret with no secrets.".to_string(),
+            })
         } else {
             Ok(Arc::new(Self {
                 current_secret,

--- a/src/standalone/deterministic.rs
+++ b/src/standalone/deterministic.rs
@@ -35,17 +35,19 @@ impl StandaloneDeterministicClient {
         let secret = self
             .config
             .get(&plaintext_field.secret_path)
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(format!(
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: format!(
                     "Provided secret path `{}` does not exist in the deterministic configuration.",
                     &plaintext_field.secret_path.0
-                ))
+                ),
             })?;
-        let current_secret = secret.current_secret.as_ref().ok_or_else(|| {
-            AlloyError::InvalidConfiguration(
-                "No current secret exists in the deterministic configuration".to_string(),
-            )
-        })?;
+        let current_secret =
+            secret
+                .current_secret
+                .as_ref()
+                .ok_or_else(|| AlloyError::InvalidConfiguration {
+                    msg: "No current secret exists in the deterministic configuration".to_string(),
+                })?;
         let key = DeterministicEncryptionKey::derive_from_secret(
             &current_secret.secret,
             tenant_id,
@@ -66,18 +68,21 @@ impl StandaloneDeterministicClient {
         let secret = self
             .config
             .get(&encrypted_field.secret_path)
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(format!(
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: format!(
                     "Provided secret path `{}` does not exist in the deterministic configuration.",
                     &encrypted_field.secret_path.0
-                ))
+                ),
             })?;
-        let standalone_secret = secret.get_secret_with_id(&key_id).ok_or_else(|| {
-            AlloyError::InvalidConfiguration(format!(
-                "Secret with key ID `{}` does not exist in the deterministic configuration",
-                key_id.0
-            ))
-        })?;
+        let standalone_secret =
+            secret
+                .get_secret_with_id(&key_id)
+                .ok_or_else(|| AlloyError::InvalidConfiguration {
+                    msg: format!(
+                        "Secret with key ID `{}` does not exist in the deterministic configuration",
+                        key_id.0
+                    ),
+                })?;
         let key = DeterministicEncryptionKey::derive_from_secret(
             &standalone_secret.secret,
             tenant_id,
@@ -139,20 +144,20 @@ impl DeterministicFieldOps for StandaloneDeterministicClient {
                     .config
                     .get(&plaintext_field.secret_path)
                     .ok_or_else(|| {
-                        AlloyError::InvalidConfiguration(format!(
+                        AlloyError::InvalidConfiguration{msg: format!(
                             "Provided secret path `{}` does not exist in the deterministic configuration.",
                             &plaintext_field.secret_path.0
-                        ))
+                        )}
                     })?;
                 let RotatableSecret {
                     current_secret,
                     in_rotation_secret,
                 } = secret.as_ref();
                 if current_secret.is_none() && in_rotation_secret.is_none() {
-                    Err(AlloyError::InvalidConfiguration(format!(
+                    Err(AlloyError::InvalidConfiguration{msg: format!(
                         "No secrets exist in the deterministic configuration for secret path `{}`.",
                         plaintext_field.secret_path.0
-                    )))?;
+                    )})?;
                 }
                 current_secret
                     .iter()
@@ -193,10 +198,10 @@ impl DeterministicFieldOps for StandaloneDeterministicClient {
                 .config
                 .get(&encrypted_field.secret_path)
                 .ok_or_else(|| {
-                    AlloyError::InvalidConfiguration(format!(
+                    AlloyError::InvalidConfiguration{msg: format!(
                         "Provided secret path `{}` does not exist in the deterministic configuration.",
                         &encrypted_field.secret_path.0
-                    ))
+                    )}
                 })?.current_secret;
             if check_rotation_no_op(
                 key_id,
@@ -226,18 +231,25 @@ impl DeterministicFieldOps for StandaloneDeterministicClient {
         _derivation_path: DerivationPath,
         _metadata: &AlloyMetadata,
     ) -> Result<Vec<u8>, AlloyError> {
-        let secret = self.config.get(&secret_path).ok_or_else(|| {
-            AlloyError::InvalidConfiguration(format!(
+        let secret =
+            self.config
+                .get(&secret_path)
+                .ok_or_else(|| AlloyError::InvalidConfiguration {
+                    msg: format!(
                 "Provided secret path `{}` does not exist in the deterministic configuration.",
                 &secret_path.0
-            ))
-        })?;
-        let in_rotation_secret = secret.in_rotation_secret.as_ref().ok_or_else(|| {
-            AlloyError::InvalidConfiguration(format!(
+            ),
+                })?;
+        let in_rotation_secret =
+            secret
+                .in_rotation_secret
+                .as_ref()
+                .ok_or_else(|| AlloyError::InvalidConfiguration {
+                    msg: format!(
                 "There is no in-rotation secret for path `{}` in the deterministic configuration.",
                 secret_path.0
-            ))
-        })?;
+            ),
+                })?;
         let key_id_header = Self::create_key_id_header(in_rotation_secret.id);
         Ok(
             ironcore_documents::v5::key_id_header::get_prefix_bytes_for_search(key_id_header)

--- a/src/standalone/standard.rs
+++ b/src/standalone/standard.rs
@@ -468,8 +468,8 @@ pub(crate) mod test {
         let error = client.encrypt(document, &metadata).await.unwrap_err();
         assert_eq!(
             error,
-            AlloyError::InvalidConfiguration{msg: 
-                "No primary secret exists in the standard configuration".to_string()
+            AlloyError::InvalidConfiguration {
+                msg: "No primary secret exists in the standard configuration".to_string()
             }
         );
         Ok(())
@@ -484,8 +484,8 @@ pub(crate) mod test {
         let error = client.encrypt(document, &metadata).await.unwrap_err();
         assert_eq!(
             error,
-            AlloyError::InvalidConfiguration{msg: 
-                "Primary secret id not found in secrets map".to_string()
+            AlloyError::InvalidConfiguration {
+                msg: "Primary secret id not found in secrets map".to_string()
             }
         );
         Ok(())
@@ -580,7 +580,9 @@ pub(crate) mod test {
         let error = client.decrypt(encrypted, &metadata).await.unwrap_err();
         assert_eq!(
             error,
-            AlloyError::ProtobufError{msg: "Unexpected EOF".to_string()}
+            AlloyError::ProtobufError {
+                msg: "Unexpected EOF".to_string()
+            }
         );
         Ok(())
     }
@@ -596,7 +598,7 @@ pub(crate) mod test {
         let error = client.decrypt(encrypted, &metadata).await.unwrap_err();
         assert_eq!(
             error,
-            AlloyError::InvalidInput{msg: 
+            AlloyError::InvalidInput{ msg:
                 "The data indicated that this was not a Standalone Standard EDEK wrapped value. Found: SaaS Shield, Deterministic Field"
                     .to_string()
             }

--- a/src/standalone/standard_attached.rs
+++ b/src/standalone/standard_attached.rs
@@ -152,7 +152,7 @@ mod test {
             .decrypt(EncryptedAttachedDocument(encrypted.to_vec()), &metadata)
             .await
             .unwrap_err();
-        assert!(matches!(err, AlloyError::DecryptError(_)))
+        assert!(matches!(err, AlloyError::DecryptError { msg: _ }))
     }
 
     #[tokio::test]

--- a/src/standalone/vector.rs
+++ b/src/standalone/vector.rs
@@ -45,20 +45,18 @@ impl StandaloneVectorClient {
         let vector_secret = self
             .config
             .get(&encrypted_vector.secret_path)
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(format!(
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: format!(
                     "Provided secret path `{}` does not exist in the vector configuration.",
                     &encrypted_vector.secret_path.0
-                ))
+                ),
             })?;
         let standalone_secret = vector_secret
             .secret
             .current_secret
             .as_ref()
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(
-                    "No current secret exists in the vector configuration".to_string(),
-                )
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: "No current secret exists in the vector configuration".to_string(),
             })?;
 
         if original_key_id.0 == standalone_secret.id && metadata.tenant_id == new_metadata.tenant_id
@@ -95,20 +93,18 @@ impl VectorOps for StandaloneVectorClient {
         let vector_secret = self
             .config
             .get(&plaintext_vector.secret_path)
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(format!(
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: format!(
                     "Provided secret path `{}` does not exist in the vector configuration.",
                     &plaintext_vector.secret_path.0
-                ))
+                ),
             })?;
         let standalone_secret = vector_secret
             .secret
             .current_secret
             .as_ref()
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(
-                    "No current secret exists in the vector configuration".to_string(),
-                )
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: "No current secret exists in the vector configuration".to_string(),
             })?;
         let key = VectorEncryptionKey::derive_from_secret(
             standalone_secret.secret.as_ref(),
@@ -137,20 +133,20 @@ impl VectorOps for StandaloneVectorClient {
         let vector_secret = self
             .config
             .get(&encrypted_vector.secret_path)
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(format!(
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: format!(
                     "Provided secret path `{}` does not exist in the vector configuration.",
                     &encrypted_vector.secret_path.0
-                ))
+                ),
             })?;
         let standalone_secret = vector_secret
             .secret
             .get_secret_with_id(&key_id)
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(format!(
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: format!(
                     "Secret with key ID `{}` does not exist in the vector configuration",
                     key_id.0
-                ))
+                ),
             })?;
         let key = VectorEncryptionKey::derive_from_secret(
             standalone_secret.secret.as_ref(),
@@ -178,21 +174,23 @@ impl VectorOps for StandaloneVectorClient {
                 let vector_secret =
                     self.config
                         .get(&plaintext_vector.secret_path)
-                        .ok_or_else(|| {
-                            AlloyError::InvalidConfiguration(format!(
+                        .ok_or_else(|| AlloyError::InvalidConfiguration {
+                            msg: format!(
                             "Provided secret path `{}` does not exist in the vector configuration.",
                             &plaintext_vector.secret_path.0
-                        ))
+                        ),
                         })?;
                 let RotatableSecret {
                     current_secret,
                     in_rotation_secret,
                 } = vector_secret.secret.as_ref();
                 if current_secret.is_none() && in_rotation_secret.is_none() {
-                    Err(AlloyError::InvalidConfiguration(format!(
-                        "No secrets exist in the vector configuration for secret path `{}`.",
-                        plaintext_vector.secret_path.0
-                    )))?;
+                    Err(AlloyError::InvalidConfiguration {
+                        msg: format!(
+                            "No secrets exist in the vector configuration for secret path `{}`.",
+                            plaintext_vector.secret_path.0
+                        ),
+                    })?;
                 }
                 current_secret
                     .iter()
@@ -229,20 +227,21 @@ impl VectorOps for StandaloneVectorClient {
         _derivation_path: DerivationPath,
         _metadata: &AlloyMetadata,
     ) -> Result<Vec<u8>, AlloyError> {
-        let vector_secret = self.config.get(&secret_path).ok_or_else(|| {
-            AlloyError::InvalidConfiguration(format!(
-                "Provided secret path `{}` does not exist in the vector configuration.",
-                &secret_path.0
-            ))
-        })?;
+        let vector_secret =
+            self.config
+                .get(&secret_path)
+                .ok_or_else(|| AlloyError::InvalidConfiguration {
+                    msg: format!(
+                        "Provided secret path `{}` does not exist in the vector configuration.",
+                        &secret_path.0
+                    ),
+                })?;
         let in_rotation_secret = vector_secret
             .secret
             .in_rotation_secret
             .as_ref()
-            .ok_or_else(|| {
-                AlloyError::InvalidConfiguration(
-                    "There is no in-rotation secret in the vector configuration.".to_string(),
-                )
+            .ok_or_else(|| AlloyError::InvalidConfiguration {
+                msg: "There is no in-rotation secret in the vector configuration.".to_string(),
             })?;
         let key_id_header = Self::create_key_id_header(in_rotation_secret.id);
         Ok(

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -75,7 +75,7 @@ pub struct EncryptedDocument {
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct RekeyEdeksBatchResult {
     pub successes: HashMap<String, EdekWithKeyIdHeader>,
-    pub failures: HashMap<String, String>,
+    pub failures: HashMap<String, AlloyError>,
 }
 
 impl From<BatchResult<EdekWithKeyIdHeader>> for RekeyEdeksBatchResult {
@@ -154,9 +154,9 @@ pub(crate) fn verify_sig(
     if ironcore_documents::v5::aes::verify_signature(aes_dek, document) {
         Ok(())
     } else {
-        Err(AlloyError::DecryptError(
-            "EDEK signature verification failed.".to_string(),
-        ))
+        Err(AlloyError::DecryptError {
+            msg: "EDEK signature verification failed.".to_string(),
+        })
     }
 }
 

--- a/src/standard_attached.rs
+++ b/src/standard_attached.rs
@@ -72,10 +72,10 @@ pub(crate) async fn encrypt_core<T: StandardDocumentOps>(
 
     let edoc = document
         .remove(&hardcoded_id)
-        .ok_or(AlloyError::EncryptError(
-            "Encryption returned a document without a passed in field. This shouldn't happen."
+        .ok_or(AlloyError::EncryptError {
+            msg: "Encryption returned a document without a passed in field. This shouldn't happen."
                 .to_string(),
-        ))?;
+        })?;
 
     Ok(EncryptedAttachedDocument(
         AttachedDocument {

--- a/src/tenant_security_client/errors.rs
+++ b/src/tenant_security_client/errors.rs
@@ -7,10 +7,10 @@ use thiserror::Error;
 #[derive(Error, Debug, PartialEq, Eq, uniffi::Enum, Clone)]
 #[non_exhaustive]
 pub enum TenantSecurityProxyError {
-    Service { err: ServiceError },
-    Kms { err: KmsError },
-    SecurityEvent { err: SecurityEventError },
-    TenantSecret { err: TenantSecretError },
+    Service { error: ServiceError },
+    Kms { error: KmsError },
+    SecurityEvent { error: SecurityEventError },
+    TenantSecret { error: TenantSecretError },
 }
 
 /// Errors communicating with the TSP
@@ -60,57 +60,65 @@ impl TenantSecurityProxyError {
         use TenantSecretError::*;
 
         match code {
-            100 => Self::Service { err: UnknownError },
+            100 => Self::Service {
+                error: UnknownError,
+            },
             101 => Self::Service {
-                err: UnauthorizedRequest,
+                error: UnauthorizedRequest,
             },
             102 => Self::Service {
-                err: InvalidRequestBody,
+                error: InvalidRequestBody,
             },
             200 => Self::Kms {
-                err: NoPrimaryKmsConfiguration,
+                error: NoPrimaryKmsConfiguration,
             },
             201 => Self::Kms {
-                err: UnknownTenantOrNoActiveKmsConfigurations,
+                error: UnknownTenantOrNoActiveKmsConfigurations,
             },
             202 => Self::Kms {
-                err: KmsConfigurationDisabled,
+                error: KmsConfigurationDisabled,
             },
             203 => Self::Kms {
-                err: InvalidProvidedEdek,
+                error: InvalidProvidedEdek,
             },
-            204 => Self::Kms { err: KmsWrapFailed },
+            204 => Self::Kms {
+                error: KmsWrapFailed,
+            },
             205 => Self::Kms {
-                err: KmsUnwrapFailed,
+                error: KmsUnwrapFailed,
             },
             206 => Self::Kms {
-                err: KmsAuthorizationFailed,
+                error: KmsAuthorizationFailed,
             },
             207 => Self::Kms {
-                err: KmsConfigurationInvalid,
+                error: KmsConfigurationInvalid,
             },
             208 => Self::Kms {
-                err: KmsUnreachable,
+                error: KmsUnreachable,
             },
-            209 => Self::Kms { err: KmsThrottled },
+            209 => Self::Kms {
+                error: KmsThrottled,
+            },
             301 => Self::SecurityEvent {
-                err: SecurityEventRejected,
+                error: SecurityEventRejected,
             },
             401 => Self::TenantSecret {
-                err: SecretCreationFailed,
+                error: SecretCreationFailed,
             },
-            _ => Self::Service { err: UnknownError },
+            _ => Self::Service {
+                error: UnknownError,
+            },
         }
     }
 
     pub fn get_code(&self) -> u16 {
         match self {
-            Self::Service { err: e, .. } => match e {
+            Self::Service { error, .. } => match error {
                 ServiceError::UnknownError => 100,
                 ServiceError::UnauthorizedRequest => 101,
                 ServiceError::InvalidRequestBody => 102,
             },
-            Self::Kms { err: e, .. } => match e {
+            Self::Kms { error, .. } => match error {
                 KmsError::NoPrimaryKmsConfiguration => 200,
                 KmsError::UnknownTenantOrNoActiveKmsConfigurations => 201,
                 KmsError::KmsConfigurationDisabled => 202,
@@ -122,10 +130,10 @@ impl TenantSecurityProxyError {
                 KmsError::KmsUnreachable => 208,
                 KmsError::KmsThrottled => 209,
             },
-            Self::SecurityEvent { err: e, .. } => match e {
+            Self::SecurityEvent { error, .. } => match error {
                 SecurityEventError::SecurityEventRejected => 301,
             },
-            Self::TenantSecret { err: e, .. } => match e {
+            Self::TenantSecret { error, .. } => match error {
                 TenantSecretError::SecretCreationFailed => 401,
             },
         }
@@ -135,10 +143,10 @@ impl TenantSecurityProxyError {
 impl Display for TenantSecurityProxyError {
     fn fmt(&self, f: &mut Formatter) -> DisplayResult {
         match self {
-            Self::Service { err } => write!(f, "{err}"),
-            Self::Kms { err } => write!(f, "{err}"),
-            Self::SecurityEvent { err } => write!(f, "{err}"),
-            Self::TenantSecret { err } => write!(f, "{err}"),
+            Self::Service { error } => write!(f, "{error}"),
+            Self::Kms { error } => write!(f, "{error}"),
+            Self::SecurityEvent { error } => write!(f, "{error}"),
+            Self::TenantSecret { error } => write!(f, "{error}"),
         }
     }
 }

--- a/src/tenant_security_client/request.rs
+++ b/src/tenant_security_client/request.rs
@@ -80,7 +80,7 @@ impl TspRequest {
                 let error_variant = TenantSecurityProxyError::code_to_error(parsed_error.code);
                 Err(AlloyError::TspError {
                     msg: error_variant.to_string(),
-                    err: error_variant,
+                    error: error_variant,
                     http_code: status.as_u16(),
                     tsp_code: parsed_error.code,
                 })

--- a/src/util.rs
+++ b/src/util.rs
@@ -103,7 +103,7 @@ pub(crate) fn create_rng<K: AsRef<[u8]>, T: AsRef<[u8]>>(key: K, hash_payload: T
 
 pub(crate) struct BatchResult<U> {
     pub successes: HashMap<FieldId, U>,
-    pub failures: HashMap<FieldId, String>,
+    pub failures: HashMap<FieldId, AlloyError>,
 }
 
 /// Applies the function `func` to all the values of `collection`, then partitions them into
@@ -118,7 +118,7 @@ where
         .into_iter()
         .map(|(key, value)| match func(value) {
             Ok(x) => Ok((key, x)),
-            Err(x) => Err((key, x.to_string())), // TODO: remove to_string when returning AlloyError works
+            Err(x) => Err((key, x)),
         })
         .partition_result();
     BatchResult {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use ironcore_alloy::{saas_shield::config::SaasShieldConfiguration, SaasShield};
-use lazy_static::lazy_static;
+use ironcore_alloy::{
+    errors::AlloyError, saas_shield::config::SaasShieldConfiguration, SaasShield,
+};
 use std::{
     env,
     error::Error,
@@ -11,17 +12,17 @@ use std::{
 };
 use uniffi::TargetLanguage;
 
-lazy_static! {
-    pub static ref CLIENT: Arc<SaasShield> = {
-        let config = SaasShieldConfiguration::new(
-            "http://localhost:32804".to_string(),
-            "0WUaXesNgbTAuLwn".to_string(),
-            false,
-            Some(1.1),
-        )
-        .unwrap();
-        SaasShield::new(&config)
-    };
+pub type TestResult = Result<(), AlloyError>;
+
+pub fn get_client() -> Arc<SaasShield> {
+    let config = SaasShieldConfiguration::new(
+        "http://localhost:32804".to_string(),
+        "0WUaXesNgbTAuLwn".to_string(),
+        false,
+        Some(1.1),
+    )
+    .unwrap();
+    SaasShield::new(&config)
 }
 
 pub(crate) fn build_dynamic_library() -> Result<ExitStatus, Box<dyn Error>> {

--- a/tests/deterministic.rs
+++ b/tests/deterministic.rs
@@ -2,17 +2,12 @@ mod common;
 
 #[cfg(feature = "integration_tests")]
 mod tests {
-    use super::*;
-    use common::CLIENT;
-
+    use crate::common::{get_client, TestResult};
     use ironcore_alloy::{
         deterministic::{DeterministicFieldOps, EncryptedField, PlaintextField},
-        errors::AlloyError,
         AlloyMetadata, DerivationPath, SecretPath, TenantId,
     };
     use std::sync::Arc;
-
-    type TestResult = Result<(), AlloyError>;
 
     fn get_metadata() -> Arc<AlloyMetadata> {
         AlloyMetadata::new_simple(TenantId("tenant-gcp-l".to_string()))
@@ -41,7 +36,10 @@ mod tests {
     async fn deterministic_encrypt_known() -> TestResult {
         let plaintext = get_plaintext();
         let metadata = get_metadata();
-        let encrypted = CLIENT.deterministic().encrypt(plaintext, &metadata).await?;
+        let encrypted = get_client()
+            .deterministic()
+            .encrypt(plaintext, &metadata)
+            .await?;
         let expected = get_ciphertext().encrypted_field;
         assert_eq!(encrypted.encrypted_field, expected);
         assert_eq!(encrypted.secret_path.0, "secret");
@@ -53,7 +51,10 @@ mod tests {
     async fn deterministic_decrypt_known() -> TestResult {
         let encrypted = get_ciphertext();
         let metadata = get_metadata();
-        let decrypted = CLIENT.deterministic().decrypt(encrypted, &metadata).await?;
+        let decrypted = get_client()
+            .deterministic()
+            .decrypt(encrypted, &metadata)
+            .await?;
         let expected = get_plaintext().plaintext_field;
         assert_eq!(decrypted.plaintext_field, expected);
         assert_eq!(decrypted.secret_path.0, "secret");
@@ -66,7 +67,7 @@ mod tests {
         let plaintext = get_plaintext();
         let fields = [("field".to_string(), plaintext)].into();
         let metadata = get_metadata();
-        let resp = CLIENT
+        let resp = get_client()
             .deterministic()
             .generate_query_field_values(fields, &metadata)
             .await?;
@@ -84,14 +85,17 @@ mod tests {
         let ciphertext = get_ciphertext();
         let fields = [("field".to_string(), ciphertext)].into();
         let metadata = get_metadata();
-        let mut resp = CLIENT
+        let mut resp = get_client()
             .deterministic()
             .rotate_fields(fields, &metadata, None)
             .await?;
         assert_eq!(resp.successes.len(), 1);
         assert_eq!(resp.failures.len(), 0);
         let rotated = resp.successes.remove("field").unwrap();
-        let decrypted = CLIENT.deterministic().decrypt(rotated, &metadata).await?;
+        let decrypted = get_client()
+            .deterministic()
+            .decrypt(rotated, &metadata)
+            .await?;
         let expected = get_plaintext().plaintext_field;
         assert_eq!(decrypted.plaintext_field, expected);
         assert_eq!(decrypted.secret_path.0, "secret");
@@ -105,7 +109,7 @@ mod tests {
         let fields = [("field".to_string(), ciphertext)].into();
         let metadata = get_metadata();
         let new_tenant_id = TenantId("tenant-aws-l".to_string());
-        let mut resp = CLIENT
+        let mut resp = get_client()
             .deterministic()
             .rotate_fields(fields, &metadata, Some(new_tenant_id.clone()))
             .await?;
@@ -113,7 +117,7 @@ mod tests {
         assert_eq!(resp.failures.len(), 0);
         let rotated = resp.successes.remove("field").unwrap();
         let new_metadata = AlloyMetadata::new_simple(new_tenant_id);
-        let decrypted = CLIENT
+        let decrypted = get_client()
             .deterministic()
             .decrypt(rotated, &new_metadata)
             .await?;

--- a/tests/standard.rs
+++ b/tests/standard.rs
@@ -274,8 +274,8 @@ mod tests {
         assert!(matches!(
             err,
             AlloyError::TspError {
-                err: TenantSecurityProxyError::Kms {
-                    err: KmsError::UnknownTenantOrNoActiveKmsConfigurations,
+                error: TenantSecurityProxyError::Kms {
+                    error: KmsError::UnknownTenantOrNoActiveKmsConfigurations,
                 },
                 ..
             }

--- a/tests/standard.rs
+++ b/tests/standard.rs
@@ -2,11 +2,10 @@ mod common;
 
 #[cfg(feature = "integration_tests")]
 mod tests {
-    use super::*;
+    use crate::common::{get_client, TestResult};
     use base64::{engine::general_purpose::STANDARD, Engine};
-    use common::CLIENT;
     use ironcore_alloy::{
-        errors::AlloyError,
+        errors::{AlloyError, KmsError, TenantSecurityProxyError},
         saas_shield::{DataEvent, SaasShieldSecurityEventOps, SecurityEvent},
         standard::{
             EdekWithKeyIdHeader, EncryptedDocument, PlaintextDocument, PlaintextDocumentWithEdek,
@@ -19,8 +18,6 @@ mod tests {
         sync::Arc,
         time::{SystemTime, UNIX_EPOCH},
     };
-
-    type TestResult = Result<(), AlloyError>;
 
     fn get_metadata() -> Arc<AlloyMetadata> {
         AlloyMetadata::new_simple(TenantId("tenant-gcp-l".to_string()))
@@ -67,7 +64,10 @@ mod tests {
     async fn standard_encrypt_works() -> TestResult {
         let plaintext = get_plaintext();
         let metadata = get_metadata();
-        let encrypted = CLIENT.standard().encrypt(plaintext, &metadata).await?;
+        let encrypted = get_client()
+            .standard()
+            .encrypt(plaintext, &metadata)
+            .await?;
         assert_eq!(encrypted.edek.0.len(), 259);
         Ok(())
     }
@@ -76,7 +76,10 @@ mod tests {
     async fn standard_decrypt_known() -> TestResult {
         let encrypted = get_ciphertext();
         let metadata = get_metadata();
-        let decrypted = CLIENT.standard().decrypt(encrypted, &metadata).await?;
+        let decrypted = get_client()
+            .standard()
+            .decrypt(encrypted, &metadata)
+            .await?;
         let expected = get_plaintext();
         assert_eq!(decrypted, expected);
         Ok(())
@@ -100,7 +103,7 @@ mod tests {
             document: doc_bytes,
         };
         let metadata = get_metadata();
-        let decrypted = CLIENT
+        let decrypted = get_client()
             .standard()
             .decrypt(document, &metadata)
             .await
@@ -114,17 +117,20 @@ mod tests {
     async fn standard_encrypt_with_existing_edek_works() -> TestResult {
         let plaintext = get_plaintext();
         let metadata = get_metadata();
-        let encrypted = CLIENT.standard().encrypt(plaintext, &metadata).await?;
+        let encrypted = get_client()
+            .standard()
+            .encrypt(plaintext, &metadata)
+            .await?;
         let plaintext2: HashMap<_, _> = [("field2".to_string(), vec![1, 2, 3, 4])].into();
         let plaintext_with_edek = PlaintextDocumentWithEdek {
             edek: encrypted.edek,
             document: plaintext2.clone(),
         };
-        let second_encrypted = CLIENT
+        let second_encrypted = get_client()
             .standard()
             .encrypt_with_existing_edek(plaintext_with_edek, &metadata)
             .await?;
-        let decrypted = CLIENT
+        let decrypted = get_client()
             .standard()
             .decrypt(second_encrypted, &metadata)
             .await?;
@@ -142,12 +148,15 @@ mod tests {
             edek: EdekWithKeyIdHeader(edek_bytes.clone()),
             document: plaintext.clone(),
         };
-        let encrypted = CLIENT
+        let encrypted = get_client()
             .standard()
             .encrypt_with_existing_edek(plaintext_with_edek, &metadata)
             .await?;
         assert_eq!(encrypted.edek.0, edek_bytes);
-        let decrypted = CLIENT.standard().decrypt(encrypted, &metadata).await?;
+        let decrypted = get_client()
+            .standard()
+            .decrypt(encrypted, &metadata)
+            .await?;
         assert_eq!(decrypted, plaintext);
         Ok(())
     }
@@ -155,7 +164,7 @@ mod tests {
     #[tokio::test]
     async fn standard_log_security_event_works() -> TestResult {
         let metadata = get_metadata();
-        CLIENT
+        get_client()
             .standard()
             .log_security_event(
                 SecurityEvent::Data {
@@ -176,7 +185,7 @@ mod tests {
     #[tokio::test]
     async fn standard_log_security_event_works_with_none() -> TestResult {
         let metadata = get_metadata();
-        CLIENT
+        get_client()
             .standard()
             .log_security_event(
                 SecurityEvent::Data {
@@ -192,7 +201,7 @@ mod tests {
     #[tokio::test]
     async fn standard_log_security_event_fails_with_negative_time() -> TestResult {
         let metadata = get_metadata();
-        let err = CLIENT
+        let err = get_client()
             .standard()
             .log_security_event(
                 SecurityEvent::Data {
@@ -211,7 +220,7 @@ mod tests {
     }
     #[tokio::test]
     async fn standard_get_searchable_edek_prefix_works() -> TestResult {
-        let prefix = CLIENT.standard().get_searchable_edek_prefix(1);
+        let prefix = get_client().standard().get_searchable_edek_prefix(1);
         let expected = [0, 0, 0, 1, 2, 0];
         assert_eq!(prefix, expected);
         Ok(())
@@ -222,7 +231,7 @@ mod tests {
         let metadata = get_metadata();
         let edek = get_ciphertext().edek;
         let edeks = [("edek".to_string(), edek)].into();
-        let all_rekeyed = CLIENT
+        let all_rekeyed = get_client()
             .standard()
             .rekey_edeks(edeks, &metadata, None)
             .await?;
@@ -240,7 +249,7 @@ mod tests {
         let edek = "CsABCjCkFe10OS/aiG6p9I0ijOirFq1nsRE8cPMog/bhOS0vYv5OCrYGZMSxOlo6dMJEYNgQ/wMYgAUiDEzjRFRtGVz1SRGWoip4CnYKcQokAKUEZIeCIuR/vrw3x2e4iWJRBfNjd/huZXKWoRxk5G5Ae6neEkkA3PhOjCcLd/QJqPK+ML9smJ0deGE4dmgtkBD1qgk0bygWrrmHZl+Oq7Sjdi63aS2JQqo9MaYvuGPoVipJdlfCMmdtsCmQefq2EP8D";
         let edek_bytes = STANDARD.decode(edek).unwrap();
         let edeks = [("edek".to_string(), EdekWithKeyIdHeader(edek_bytes))].into();
-        let all_rekeyed = CLIENT
+        let all_rekeyed = get_client()
             .standard()
             .rekey_edeks(edeks, &metadata, None)
             .await?;
@@ -250,6 +259,27 @@ mod tests {
         // This is now a V5 document, which starts with the KeyIdHeader
         // First 4 bytes are KMS config ID 511
         assert!(rekeyed.0.starts_with(&[0, 0, 1, 255, 2, 0]));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_error_variant() -> TestResult {
+        let encrypted = get_ciphertext();
+        let metadata = AlloyMetadata::new_simple(TenantId("fake-tenant".to_string()));
+        let err = get_client()
+            .standard()
+            .decrypt(encrypted, &metadata)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            AlloyError::TspError {
+                err: TenantSecurityProxyError::Kms {
+                    err: KmsError::UnknownTenantOrNoActiveKmsConfigurations,
+                },
+                ..
+            }
+        ));
         Ok(())
     }
 }


### PR DESCRIPTION
Major changes to the error:
- Remove TenantSecurityError entirely. 
  - Its TspError variant moved to AlloyError. All other variants moved into AlloyError
- Remove `#[uniffi(flat_error)]` from AlloyError. 
  - This means that the fields inside the variant are no longer stringified, so generated languages can access them
  - This required us to switch to the enum style with named fields, which is huge code churn
- Changed BatchResult failures to AlloyError. Now they can treat them the same way they can other errors we hand them

Misc changes:
- Changed Rust integration tests to make a new Client for each test to fix the intermittent dispatch dropped errors
- Added some Python/Kotlin tests around TspError. Because these have to come from the TSP itself and are therefore integration tests, they're skipped/ignored by default