### PR TITLE
Update to uniffi 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "ironcore-alloy"
-version = "0.9.2-pre.26"
+version = "0.10.0"
 dependencies = [
  "aes-gcm",
  "aes-siv",
@@ -2181,9 +2181,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "uniffi"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935007d0071c47757c5123a5432199de25586bce196f0d9c0edd8134e514fc36"
+checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
 dependencies = [
  "anyhow",
  "camino",
@@ -2195,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde32a2b8f138a4a8510effba7e7b666b292055a9f0a6ee7af634f399bd10439"
+checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
 dependencies = [
  "anyhow",
  "askama",
@@ -2220,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f67866ba8fc0c5b20e74a20482856b5486990981ce4cef74b88599fd292e871"
+checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
@@ -2231,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff709037c1cefcc39c1c754de424fa8fb753607f01332e57cdcab0e90bb09dd"
+checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
  "syn",
@@ -2241,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b3af79cd094c4b3ed098cb2549150dd7b5585cdb106db442846d2acab38d4"
+checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9430116412cbf98811883141aa14c004912e39e9cde1ca28c56234848b9692"
+checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
 dependencies = [
  "bincode",
  "camino",
@@ -2277,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9ff57d4dc24717f0fa9bc01e22e030d1da252798660878b457f7e5bfdb93c"
+checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2289,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c83d57347678c90393f879090b9c6ecbf3521061eb3caca55964508eca1663"
+checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
 dependencies = [
  "anyhow",
  "camino",
@@ -2302,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a2e5cca029904bb8bdf48492ba61e01fd48bafff907d3bf8f09d313d869bf"
+checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -2476,9 +2476,9 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "weedle2"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69eb0e267122e2d2eb8c8fd7e7d0d6b9d2043d3a52c6c7fb0a6653ee492d04fd"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "ironcore-alloy"
-version = "0.10.0"
+version = "0.9.2-pre.26"
 dependencies = [
  "aes-gcm",
  "aes-siv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironcore-alloy"
-version = "0.9.2-pre.26"
+version = "0.10.0"
 description = "IronCore Labs SDK for all your different Application Layer Encryption needs"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironcore-alloy"
-version = "0.10.0"
+version = "0.9.2-pre.26"
 description = "IronCore Labs SDK for all your different Application Layer Encryption needs"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 edition = "2021"


### PR DESCRIPTION
uniffi 0.26.0 was yanked due to a memory leak. Need to update this before releasing (Rust won't have a Cargo.lock but generated code will have these exact dependencies).