### PR TITLE
Improve performance, fix bug with standard EDEK parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,9 +390,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -1036,6 +1036,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_distr",
+ "rayon",
  "regex",
  "reqwest",
  "ring",
@@ -1050,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "ironcore-documents"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd19765db5c9c4d9d1953cf161cc3d0e24230149b044ba659aa394dba70832fc"
+checksum = "3e7ed36f05a5f56bb3757f2d87c8dea2367f2ef6ffec34e3ebf374a8dbff75bb"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -1600,9 +1601,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
  "base64 0.22.0",
  "bytes",
@@ -1662,9 +1663,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags",
  "errno",
@@ -1699,15 +1700,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1927,18 +1928,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2135,7 +2136,7 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 [[package]]
 name = "uniffi"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "anyhow",
  "camino",
@@ -2148,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "anyhow",
  "askama",
@@ -2172,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "quote",
  "syn",
@@ -2181,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2197,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "bincode",
  "camino",
@@ -2214,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2225,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "anyhow",
  "camino",
@@ -2237,7 +2238,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -2407,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs#ba227cc09465b8dde105bb97ec2ed7952eab2df7"
+source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
 dependencies = [
  "nom",
 ]
@@ -2425,35 +2426,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "ironcore-documents"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7ed36f05a5f56bb3757f2d87c8dea2367f2ef6ffec34e3ebf374a8dbff75bb"
+checksum = "caa3f9b0cb178f9448ea1e10a66ab71438a3faa4105d7b61eafa1b008a17eb21"
 dependencies = [
  "aes-gcm",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,8 @@ path = "uniffi-bindgen.rs"
 # 6.9M vs 1.5M in initial testing. Can further have `strip` (the Unix utility) run on it to save ~0.2 MB more.
 # WARNING: be careful changing this, since downstream integration tests (in "core/tests") depend on this profile.
 [profile.release]
-opt-level = 3     # Our crypto basically requires opt-level 3 for reasonable speeds
-lto = true        # Enable Link Time Optimization
-codegen-units = 1 # Reduce number of codegen units to increase optimizations.
-panic = 'abort'   # Abort on panic
-strip = 'debug'
+opt-level = 3       # Our crypto basically requires opt-level 3 for reasonable speeds
+lto = true          # Enable Link Time Optimization
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic
+strip = 'debuginfo'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,10 @@ ring = "0.17"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = { version = "1.0.96", features = ["float_roundtrip"] }
 thiserror = "1.0.50"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", features = ["tokio"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", features = [
+    "tokio",
+    "cli",
+] }
 z85 = "3.0.5"
 
 [dev-dependencies]
@@ -58,7 +61,6 @@ hex-literal = "0.4.1"
 lazy_static = "1.4"
 proptest = "1.2.0"
 tokio = { version = "1.33", features = ["macros", "rt-multi-thread"] }
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", features = ["cli"] }
 uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs" }
 z85 = "3.0.5"
 
@@ -80,7 +82,6 @@ name = "ironcore_alloy"
 [[bin]]
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
-required-features = ["uniffi/cli"]
 
 # used to create the smallest cdylib binary we can to ship with the library in each ecosystem.
 # 6.9M vs 1.5M in initial testing. Can further have `strip` (the Unix utility) run on it to save ~0.2 MB more.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bytes = { version = "1.4.0", features = ["serde"] }
 convert_case = "0.6.0"
 futures = "0.3.29"
 hmac = { version = "0.12.1", features = ["std"] }
-ironcore-documents = "0.1"
+ironcore-documents = "0.2"
 itertools = "0.12"
 ndarray = "0.15.6"
 ndarray-rand = "0.14.0"
@@ -32,6 +32,7 @@ protobuf = { version = "3.3", features = ["with-bytes"] }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_distr = "0.4.3"
+rayon = "1.10.0"
 regex = "1.10.2"
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
@@ -41,10 +42,7 @@ ring = "0.17"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = { version = "1.0.96", features = ["float_roundtrip"] }
 thiserror = "1.0.50"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", features = [
-    "cli",
-    "tokio",
-] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", features = ["tokio"] }
 z85 = "3.0.5"
 
 [dev-dependencies]
@@ -60,6 +58,7 @@ hex-literal = "0.4.1"
 lazy_static = "1.4"
 proptest = "1.2.0"
 tokio = { version = "1.33", features = ["macros", "rt-multi-thread"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", features = ["cli"] }
 uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs" }
 z85 = "3.0.5"
 
@@ -81,13 +80,14 @@ name = "ironcore_alloy"
 [[bin]]
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
+required-features = ["uniffi/cli"]
 
 # used to create the smallest cdylib binary we can to ship with the library in each ecosystem.
 # 6.9M vs 1.5M in initial testing. Can further have `strip` (the Unix utility) run on it to save ~0.2 MB more.
 # WARNING: be careful changing this, since downstream integration tests (in "core/tests") depend on this profile.
 [profile.release]
-opt-level = 3       # Check 'z' sometimes in case much smaller. Initial testing showed 0.1M size difference but 25% performance hit, so 3 is better.
-lto = true          # Enable Link Time Optimization
-codegen-units = 1   # Reduce number of codegen units to increase optimizations.
-panic = 'abort'     # Abort on panic
-strip = 'debuginfo'
+opt-level = 3     # Our crypto basically requires opt-level 3 for reasonable speeds
+lto = true        # Enable Link Time Optimization
+codegen-units = 1 # Reduce number of codegen units to increase optimizations.
+panic = 'abort'   # Abort on panic
+strip = 'symbols'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bytes = { version = "1.4.0", features = ["serde"] }
 convert_case = "0.6.0"
 futures = "0.3.29"
 hmac = { version = "0.12.1", features = ["std"] }
-ironcore-documents = "0.2"
+ironcore-documents = "0.2.1"
 itertools = "0.12"
 ndarray = "0.15.6"
 ndarray-rand = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,4 +91,4 @@ opt-level = 3     # Our crypto basically requires opt-level 3 for reasonable spe
 lto = true        # Enable Link Time Optimization
 codegen-units = 1 # Reduce number of codegen units to increase optimizations.
 panic = 'abort'   # Abort on panic
-strip = 'symbols'
+strip = 'debug'

--- a/benches/ironcore_alloy_bench.rs
+++ b/benches/ironcore_alloy_bench.rs
@@ -205,8 +205,11 @@ fn tsp_benches(c: &mut Criterion) {
     c.bench_function("TSP - batch encrypt 10 documents, 10 fields, 10B", |b| {
         b.to_async(Runtime::new().unwrap()).iter_batched(
             || {
-                PlaintextDocuments((0..10).fold(HashMap::new(), |mut acc, i| {
-                    let doc = generate_plaintext(10, 10, &mut rng);
+                let num_documents = 10;
+                let num_fields = 10;
+                let field_size = 10;
+                PlaintextDocuments((0..num_documents).fold(HashMap::new(), |mut acc, i| {
+                    let doc = generate_plaintext(field_size, num_fields, &mut rng);
                     acc.insert(DocumentId(format!("doc{}", i)), doc);
                     acc
                 }))

--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1704075545,
-        "narHash": "sha256-L3zgOuVKhPjKsVLc3yTm2YJ6+BATyZBury7wnhyc8QU=",
+        "lastModified": 1713838472,
+        "narHash": "sha256-lCdDz6/YgyXdFRHall3P+dCETRpfz3Pi9eREnA9RX6k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a0df72e106322b67e9c6e591fe870380bd0da0d5",
+        "rev": "28a9436d356181603fb0d333565431c3d952f299",
         "type": "github"
       },
       "original": {

--- a/kotlin/benchmarks/src/SaasShieldBenchmark.kt
+++ b/kotlin/benchmarks/src/SaasShieldBenchmark.kt
@@ -58,12 +58,17 @@ class SaasShieldBenchmark {
         }
     }
 
+    @TearDown
+    fun tearDown() {
+        saasShieldSdk.close()
+    }
+
     fun generatePlaintextDocument(bytesPerField: Int, numFields: Int): PlaintextDocument {
         val documentMap = HashMap<String, PlaintextBytes>()
         for (i in 1..numFields) {
             val byteArray = ByteArray(bytesPerField)
             kotlin.random.Random.nextBytes(byteArray)
-            documentMap.put("doc" + i, byteArray)
+            documentMap.put("field" + i, byteArray)
         }
         return documentMap
     }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -10,8 +10,8 @@ group = "com.ironcorelabs"
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    kotlin("jvm") version "1.8.10"
-    id("org.jetbrains.dokka") version "1.9.0"
+    kotlin("jvm") version "1.9.23"
+    id("org.jetbrains.dokka") version "1.9.20"
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
@@ -23,8 +23,8 @@ plugins {
 
     // benchmark deps
     java
-    id("org.jetbrains.kotlinx.benchmark") version "0.4.9"
-    kotlin("plugin.allopen") version "1.9.20"
+    id("org.jetbrains.kotlinx.benchmark") version "0.4.10"
+    kotlin("plugin.allopen") version "1.9.23"
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
@@ -55,8 +55,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     // Use the JUnit 5 integration.
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.1")
-    implementation("net.java.dev.jna:jna:5.13.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    implementation("net.java.dev.jna:jna:5.14.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
     implementation("org.jetbrains.kotlin:kotlin-scripting-jvm")
     benchmarksImplementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.4.9")
     benchmarksImplementation(sourceSets.main.get().output + sourceSets.main.get().runtimeClasspath)
@@ -129,7 +129,7 @@ benchmark {
     targets {
         register(benchmarks) {
             this as JvmBenchmarkTarget
-            jmhVersion = "1.21"
+            jmhVersion = "1.37"
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 profile = "default"
-channel = "1.75.0"
+channel = "1.77.2"
 components = ["rust-src", "rust-analyzer", "llvm-tools"]

--- a/src/saas_shield/deterministic.rs
+++ b/src/saas_shield/deterministic.rs
@@ -16,6 +16,7 @@ use crate::FieldId;
 use crate::{alloy_client_trait::AlloyClient, AlloyMetadata, DerivationPath, SecretPath, TenantId};
 use ironcore_documents::v5::key_id_header::{EdekType, PayloadType};
 use itertools::Itertools;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -197,7 +198,10 @@ impl DeterministicFieldOps for SaasShieldDeterministicClient {
             )
         };
         Ok(perform_batch_action(
-            encrypted_fields.0.into_iter().map(|(k, v)| (FieldId(k), v)),
+            encrypted_fields
+                .0
+                .into_par_iter()
+                .map(|(k, v)| (FieldId(k), v)),
             decrypt_field,
         )
         .into())
@@ -318,7 +322,10 @@ impl DeterministicFieldOps for SaasShieldDeterministicClient {
             }
         };
         Ok(perform_batch_action(
-            encrypted_fields.0.into_iter().map(|(k, v)| (FieldId(k), v)),
+            encrypted_fields
+                .0
+                .into_par_iter()
+                .map(|(k, v)| (FieldId(k), v)),
             reencrypt_field,
         )
         .into())

--- a/src/saas_shield/standard.rs
+++ b/src/saas_shield/standard.rs
@@ -527,7 +527,6 @@ fn find_cmk_edek_v5(
             .iter()
             .map(|edek| edek.kmsConfigId as u32)
             .collect_vec();
-        dbg!(&kms_config_ids);
         maybe_cmk_edeks
             .into_iter()
             .find(|edek| edek.kmsConfigId as u32 == kms_config_id)

--- a/src/saas_shield/standard.rs
+++ b/src/saas_shield/standard.rs
@@ -16,15 +16,18 @@ use crate::{DocumentId, FieldId, PlaintextBytes, TenantId};
 use bytes::Bytes;
 use futures::future::{join_all, FutureExt};
 use ironcore_documents::aes::EncryptionKey;
+use ironcore_documents::cmk_edek;
 use ironcore_documents::cmk_edek::EncryptedDek;
 use ironcore_documents::icl_header_v4::v4document_header::EdekWrapper;
 use ironcore_documents::icl_header_v4::{self, V4DocumentHeader};
+use ironcore_documents::v4::validate_v4_header;
 use ironcore_documents::v5::key_id_header::{
     decode_version_prefixed_value, EdekType, KeyId, KeyIdHeader, PayloadType,
 };
-use ironcore_documents::{cmk_edek, v4};
+use itertools::Itertools;
 use protobuf::Message;
 use rand::{CryptoRng, RngCore};
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::convert::identity;
 use std::sync::{Arc, Mutex};
@@ -50,9 +53,19 @@ impl EdekParts {
     /// EncryptedDeks bytes ready to send to the TSP.
     fn get_edek_bytes(&self) -> Result<Vec<u8>, AlloyError> {
         match self {
-            EdekParts::V5(_, v4_document_header) | EdekParts::V4(v4_document_header) => {
+            EdekParts::V5(kms_config_id, v4_document_header) => {
+                let fixed_edek = fix_encrypted_dek(find_cmk_edek_v5(
+                    &v4_document_header.signed_payload.edeks,
+                    kms_config_id.0,
+                )?)?;
+                let edek_bytes = fixed_edek
+                    .write_to_bytes()
+                    .expect("Writing to bytes is safe");
+                Ok(edek_bytes)
+            }
+            EdekParts::V4(v4_document_header) => {
                 let fixed_edek =
-                    fix_encrypted_dek(find_cmk_edek(&v4_document_header.signed_payload.edeks)?)?;
+                    fix_encrypted_dek(find_cmk_edek_v4(&v4_document_header.signed_payload.edeks)?)?;
                 let edek_bytes = fixed_edek
                     .write_to_bytes()
                     .expect("Writing to bytes is safe");
@@ -81,7 +94,7 @@ impl SaasShieldStandardClient {
         }
     }
 
-    fn encrypt_document<R: RngCore + CryptoRng>(
+    fn encrypt_document<R: RngCore + CryptoRng + Send>(
         rng: Arc<Mutex<R>>,
         tsc_edek: Vec<u8>,
         dek: EncryptionKey,
@@ -149,24 +162,34 @@ impl SaasShieldStandardClient {
                 },
                 remaining_bytes,
             )) => {
-                let expected_edek_type = Self::get_edek_type();
-                let expected_payload_type = Self::get_payload_type();
-                if edek_type == expected_edek_type && payload_type == expected_payload_type {
-                    let v4_document_header = v4_proto_from_bytes(remaining_bytes)?;
-                    Ok(EdekParts::V5(key_id, v4_document_header))
+                // standard_attached uses a key ID of 0 to indicate V4 headers, as they can't exist in V5
+                if key_id.0 == 0 {
+                    Ok(v4_proto_from_bytes(&remaining_bytes).map(EdekParts::V4)?)
                 } else {
-                    Err(AlloyError::InvalidInput{ msg:
-                format!("The data indicated that this was not a {expected_edek_type} {expected_payload_type} wrapped value. Found: {edek_type}, {payload_type}"),
-                })
+                    let expected_edek_type = Self::get_edek_type();
+                    let expected_payload_type = Self::get_payload_type();
+                    if edek_type == expected_edek_type && payload_type == expected_payload_type {
+                        let v4_document_header = v4_proto_from_bytes(remaining_bytes)?;
+                        Ok(EdekParts::V5(key_id, v4_document_header))
+                    } else {
+                        Err(AlloyError::InvalidInput{ msg:
+                            format!("The data indicated that this was not a {expected_edek_type} {expected_payload_type} wrapped value. Found: {edek_type}, {payload_type}"),
+                        })
+                    }
                 }
             }
             // This is the case where the value did not have a key id header. This means it's either a v4 or v3.
             Err(_) => {
-                let bytes: Bytes = encrypted_bytes.0.into();
-                // Try to decode v4 first, since it has a specific form. V3 is just proto bytes.
-                v4::attached::decode_attached_edoc(bytes.clone())
-                    .map(|(edek, _)| EdekParts::V4(edek))
-                    .or_else(|_| Ok(EdekParts::V3(bytes)))
+                Ok(v4_proto_from_bytes(&encrypted_bytes.0)
+                    .ok()
+                    .and_then(|maybe_parsed_v4| {
+                        // Check that the parsing succeeded, meaning it is actually V4
+                        validate_v4_header(&maybe_parsed_v4).then(|| EdekParts::V4(maybe_parsed_v4))
+                    })
+                    .unwrap_or(
+                        // Parsing as V4 failed, so V3 is our fallback
+                        EdekParts::V3(encrypted_bytes.0.into()),
+                    ))
             }
         }
     }
@@ -179,7 +202,7 @@ impl SaasShieldStandardClient {
         metadata: &AlloyMetadata,
     ) -> Result<(BatchUnwrapKeyResponse, HashMap<DocumentId, AlloyError>), AlloyError>
     where
-        T: IntoIterator<Item = (&'a str, EdekWithKeyIdHeader)>,
+        T: IntoParallelIterator<Item = (&'a str, EdekWithKeyIdHeader)>,
     {
         let request_metadata = metadata.clone().try_into()?;
         let decompose_edek = |edek_with_header: EdekWithKeyIdHeader| {
@@ -256,7 +279,7 @@ impl StandardDocumentOps for SaasShieldStandardClient {
         let request_metadata = metadata.clone().try_into()?;
         let document_ids = plaintext_documents.0.keys().map(|d| d.0.as_str()).collect();
         let BatchWrapKeyResponse {
-            mut keys,
+            keys,
             failures: tsp_failures,
         } = self
             .tenant_security_client
@@ -264,10 +287,10 @@ impl StandardDocumentOps for SaasShieldStandardClient {
             .await?;
         let docs_and_keys = plaintext_documents
             .0
-            .into_iter()
+            .into_par_iter()
             .map(|(document_id, document)| {
-                let maybe_keys = keys.remove(&document_id.0);
-                (document_id, (document, maybe_keys))
+                let maybe_keys = keys.get(&document_id.0);
+                (document_id, (document, maybe_keys.cloned()))
             });
         let encrypt_document =
             |(plaintext_document, maybe_keys): (PlaintextDocument, Option<WrapKeyResponse>)| {
@@ -327,17 +350,17 @@ impl StandardDocumentOps for SaasShieldStandardClient {
     ) -> Result<StandardDecryptBatchResult, AlloyError> {
         let edeks_with_headers = encrypted_documents
             .0
-            .iter()
+            .par_iter()
             .map(|(k, v)| (k.0.as_str(), v.edek.clone()));
-        let (mut batch_unwrap_response, edek_failures) = self
+        let (batch_unwrap_response, edek_failures) = self
             .batch_unwrap_edeks(edeks_with_headers, metadata)
             .await?;
         let docs_and_keys = encrypted_documents
             .0
-            .into_iter()
+            .into_par_iter()
             .map(|(document_id, document)| {
-                let maybe_keys = batch_unwrap_response.keys.remove(&document_id.0);
-                (document_id, (document, maybe_keys))
+                let maybe_keys = batch_unwrap_response.keys.get(&document_id.0);
+                (document_id, (document, maybe_keys.cloned()))
             });
         let decrypt_document =
             |(encrypted_document, maybe_keys): (EncryptedDocument, Option<UnwrapKeyResponse>)| {
@@ -418,17 +441,17 @@ impl StandardDocumentOps for SaasShieldStandardClient {
     ) -> Result<StandardEncryptBatchResult, AlloyError> {
         let edeks_with_headers = plaintext_documents
             .0
-            .iter()
+            .par_iter()
             .map(|(k, v)| (k.0.as_str(), v.edek.clone()));
-        let (mut batch_unwrap_response, edek_failures) = self
+        let (batch_unwrap_response, edek_failures) = self
             .batch_unwrap_edeks(edeks_with_headers, metadata)
             .await?;
         let docs_and_keys = plaintext_documents
             .0
-            .into_iter()
+            .into_par_iter()
             .map(|(document_id, document)| {
-                let maybe_keys = batch_unwrap_response.keys.remove(&document_id.0);
-                (document_id, (document, maybe_keys))
+                let maybe_keys = batch_unwrap_response.keys.get(&document_id.0);
+                (document_id, (document, maybe_keys.cloned()))
             });
         let encrypt_document = |(plaintext_document, maybe_keys): (
             PlaintextDocumentWithEdek,
@@ -481,7 +504,44 @@ impl SaasShieldSecurityEventOps for SaasShieldStandardClient {
     }
 }
 
-fn find_cmk_edek(edeks: &[EdekWrapper]) -> Result<&EncryptedDek, AlloyError> {
+fn find_cmk_edek_v5(
+    edeks: &[EdekWrapper],
+    kms_config_id: u32,
+) -> Result<&EncryptedDek, AlloyError> {
+    let maybe_cmk_edeks = edeks
+        .iter()
+        .filter_map(|edek| {
+            if edek.has_cmk_edek() {
+                Some(edek.cmk_edek())
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+    if maybe_cmk_edeks.is_empty() {
+        Err(AlloyError::DecryptError {
+            msg: "No Saas Shield EDEK found.".to_string(),
+        })
+    } else {
+        let kms_config_ids = maybe_cmk_edeks
+            .iter()
+            .map(|edek| edek.kmsConfigId as u32)
+            .collect_vec();
+        dbg!(&kms_config_ids);
+        maybe_cmk_edeks
+            .into_iter()
+            .find(|edek| edek.kmsConfigId as u32 == kms_config_id)
+            .ok_or_else(|| AlloyError::DecryptError {
+                msg: format!(
+                    "Document header malformed. Header key ID ({}) not found in EDEKs. Found: [{}]",
+                    kms_config_id,
+                    kms_config_ids.into_iter().join(",")
+                ),
+            })
+    }
+}
+
+fn find_cmk_edek_v4(edeks: &[EdekWrapper]) -> Result<&EncryptedDek, AlloyError> {
     let maybe_edek_wrapper = edeks.iter().find(|edek| edek.has_cmk_edek());
     let cmk_edek = maybe_edek_wrapper
         .map(|edek| edek.cmk_edek())
@@ -610,25 +670,25 @@ mod test {
     }
 
     #[test]
-    fn parse_old_v5_document_works() {
+    fn parse_old_v4_document_works() {
         let edek_and_header = EdekWithKeyIdHeader(vec![
-            0, 0, 0, 0, 2, 0, 10, 36, 10, 32, 64, 210, 116, 17, 37, 169, 25, 195, 73, 47, 59, 120,
-            34, 200, 205, 142, 3, 154, 115, 130, 188, 198, 244, 161, 170, 163, 153, 254, 43, 237,
-            157, 167, 16, 1, 18, 215, 1, 18, 212, 1, 18, 209, 1, 10, 192, 1, 10, 48, 63, 225, 165,
-            108, 33, 17, 151, 119, 230, 185, 159, 203, 90, 67, 250, 185, 117, 54, 184, 68, 240,
-            128, 92, 176, 48, 35, 52, 183, 27, 153, 15, 247, 241, 63, 221, 179, 246, 99, 9, 98,
-            221, 121, 156, 193, 220, 197, 225, 126, 16, 255, 3, 24, 128, 5, 34, 12, 39, 49, 127,
-            75, 144, 142, 37, 173, 138, 210, 233, 129, 42, 120, 10, 118, 10, 113, 10, 36, 0, 165,
-            4, 100, 135, 130, 34, 228, 127, 190, 188, 55, 199, 103, 184, 137, 98, 81, 5, 243, 99,
-            119, 248, 110, 101, 114, 150, 161, 28, 100, 228, 110, 64, 123, 169, 222, 18, 73, 0,
-            220, 248, 78, 140, 39, 11, 119, 244, 9, 168, 242, 190, 48, 191, 108, 152, 157, 29, 120,
-            97, 56, 118, 104, 45, 144, 16, 245, 170, 9, 52, 111, 40, 22, 174, 185, 135, 102, 95,
-            142, 171, 180, 163, 118, 46, 183, 105, 45, 137, 66, 170, 61, 49, 166, 47, 184, 99, 232,
-            86, 42, 73, 118, 87, 194, 50, 103, 109, 176, 41, 144, 121, 250, 182, 16, 255, 3, 50,
-            12, 116, 101, 110, 97, 110, 116, 45, 103, 99, 112, 45, 108,
+            10, 36, 10, 32, 64, 210, 116, 17, 37, 169, 25, 195, 73, 47, 59, 120, 34, 200, 205, 142,
+            3, 154, 115, 130, 188, 198, 244, 161, 170, 163, 153, 254, 43, 237, 157, 167, 16, 1, 18,
+            215, 1, 18, 212, 1, 18, 209, 1, 10, 192, 1, 10, 48, 63, 225, 165, 108, 33, 17, 151,
+            119, 230, 185, 159, 203, 90, 67, 250, 185, 117, 54, 184, 68, 240, 128, 92, 176, 48, 35,
+            52, 183, 27, 153, 15, 247, 241, 63, 221, 179, 246, 99, 9, 98, 221, 121, 156, 193, 220,
+            197, 225, 126, 16, 255, 3, 24, 128, 5, 34, 12, 39, 49, 127, 75, 144, 142, 37, 173, 138,
+            210, 233, 129, 42, 120, 10, 118, 10, 113, 10, 36, 0, 165, 4, 100, 135, 130, 34, 228,
+            127, 190, 188, 55, 199, 103, 184, 137, 98, 81, 5, 243, 99, 119, 248, 110, 101, 114,
+            150, 161, 28, 100, 228, 110, 64, 123, 169, 222, 18, 73, 0, 220, 248, 78, 140, 39, 11,
+            119, 244, 9, 168, 242, 190, 48, 191, 108, 152, 157, 29, 120, 97, 56, 118, 104, 45, 144,
+            16, 245, 170, 9, 52, 111, 40, 22, 174, 185, 135, 102, 95, 142, 171, 180, 163, 118, 46,
+            183, 105, 45, 137, 66, 170, 61, 49, 166, 47, 184, 99, 232, 86, 42, 73, 118, 87, 194,
+            50, 103, 109, 176, 41, 144, 121, 250, 182, 16, 255, 3, 50, 12, 116, 101, 110, 97, 110,
+            116, 45, 103, 99, 112, 45, 108,
         ]);
         let edek_parts = SaasShieldStandardClient::decompose_edek_header(edek_and_header).unwrap();
-        assert!(matches!(edek_parts, EdekParts::V5(_, _)));
+        assert!(matches!(edek_parts, EdekParts::V4(_)));
         let edek_bytes = edek_parts.get_edek_bytes().unwrap();
         let encrypted_deks: cmk_edek::EncryptedDeks =
             Message::parse_from_bytes(&edek_bytes).unwrap();

--- a/src/standalone/deterministic.rs
+++ b/src/standalone/deterministic.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use ironcore_documents::v5::key_id_header::{EdekType, PayloadType};
 use itertools::Itertools;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -158,7 +159,10 @@ impl DeterministicFieldOps for StandaloneDeterministicClient {
             self.decrypt_sync(encrypted_field, &metadata.tenant_id)
         };
         Ok(perform_batch_action(
-            encrypted_fields.0.into_iter().map(|(k, v)| (FieldId(k), v)),
+            encrypted_fields
+                .0
+                .into_par_iter()
+                .map(|(k, v)| (FieldId(k), v)),
             decrypt_field,
         )
         .into())
@@ -252,7 +256,10 @@ impl DeterministicFieldOps for StandaloneDeterministicClient {
             }
         };
         Ok(perform_batch_action(
-            encrypted_fields.0.into_iter().map(|(k, v)| (FieldId(k), v)),
+            encrypted_fields
+                .0
+                .into_par_iter()
+                .map(|(k, v)| (FieldId(k), v)),
             reencrypt_field,
         )
         .into())

--- a/src/standalone/standard.rs
+++ b/src/standalone/standard.rs
@@ -8,7 +8,7 @@ use crate::standard::{
     PlaintextDocuments, PlaintextDocumentsWithEdeks, RekeyEdeksBatchResult,
     StandardDecryptBatchResult, StandardDocumentOps, StandardEncryptBatchResult,
 };
-use crate::util::{get_rng, hash256, perform_batch_action, OurReseedingRng};
+use crate::util::{hash256, perform_batch_action, OurReseedingRng};
 use crate::DocumentId;
 use crate::{alloy_client_trait::AlloyClient, AlloyMetadata, Secret, TenantId};
 use ironcore_documents::aes::EncryptionKey;
@@ -59,7 +59,7 @@ impl StandaloneStandardClient {
         let (secret_id, secret) = self.get_current_secret_and_id()?;
         let per_tenant_kek = derive_aes_encryption_key(&secret.secret, &metadata.tenant_id);
         let (aes_dek, v4_doc) = v5::aes::generate_aes_edek_and_sign(
-            &mut *get_rng(&self.rng),
+            self.rng.clone(),
             per_tenant_kek,
             None,
             secret_id.to_string().as_str(),
@@ -240,7 +240,7 @@ impl StandardDocumentOps for StandaloneStandardClient {
             let encryption_key =
                 derive_aes_encryption_key(&current_secret.secret, parsed_new_tenant_id);
             let (_, v4_doc) = v5::aes::generate_aes_edek_and_sign(
-                &mut *get_rng(&self.rng),
+                self.rng.clone(),
                 encryption_key,
                 Some(dek),
                 current_secret_id.to_string().as_str(),

--- a/src/standard_attached.rs
+++ b/src/standard_attached.rs
@@ -1,12 +1,14 @@
 use crate::{
     create_batch_result_struct,
     errors::AlloyError,
-    standard::{EdekWithKeyIdHeader, EncryptedDocument, PlaintextDocument, StandardDocumentOps},
+    standard::{
+        EdekWithKeyIdHeader, EncryptedDocument, EncryptedDocuments, PlaintextDocument,
+        PlaintextDocuments, StandardDocumentOps,
+    },
     util::{perform_batch_action, v4_proto_from_bytes, BatchResult},
     AlloyMetadata, DocumentId, EncryptedBytes, FieldId, PlaintextBytes, TenantId,
 };
 use bytes::Bytes;
-use futures::{future::join_all, FutureExt};
 use ironcore_documents::{
     aes::IvAndCiphertext,
     v4,
@@ -16,7 +18,8 @@ use ironcore_documents::{
         key_id_header::{self, KeyId, KeyIdHeader},
     },
 };
-use std::{collections::HashMap, convert::identity};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::collections::HashMap;
 use uniffi::custom_newtype;
 
 // TODO: This newtype can't include PlaintextBytes because of a bug with generated Python
@@ -100,40 +103,24 @@ pub trait StandardAttachedDocumentOps {
     fn get_searchable_edek_prefix(&self, id: i32) -> Vec<u8>;
 }
 
-pub(crate) async fn encrypt_core<T: StandardDocumentOps>(
-    standard_client: &T,
-    plaintext_document: PlaintextBytes,
-    metadata: &AlloyMetadata,
+fn encrypted_document_to_attached(
+    encrypted_document: EncryptedDocument,
 ) -> Result<EncryptedAttachedDocument, AlloyError> {
-    // In order to call the encrypt on standard, we need a map. This is just a hardcoded string we will
-    // use to encrypt.
-    let hardcoded_id = FieldId("".to_string());
+    let hardcoded_field_id = FieldId("".to_string());
     let EncryptedDocument {
         edek: edek_with_key_id_bytes,
         // Mutable so we can removed the hardcoded key below.
         mut document,
-    } = standard_client
-        .encrypt(
-            PlaintextDocument(
-                [(hardcoded_id.clone(), plaintext_document)]
-                    .into_iter()
-                    .collect(),
-            ),
-            metadata,
-        )
-        .await?;
+    } = encrypted_document;
     let (key_id_header, edek_bytes) =
         key_id_header::decode_version_prefixed_value(edek_with_key_id_bytes.0.into())?;
-
     let edek = v4_proto_from_bytes(edek_bytes)?;
-
     let edoc = document
-        .remove(&hardcoded_id)
+        .remove(&hardcoded_field_id)
         .ok_or(AlloyError::EncryptError {
             msg: "Encryption returned a document without a passed in field. This shouldn't happen."
                 .to_string(),
         })?;
-
     Ok(EncryptedAttachedDocument(
         AttachedDocument {
             key_id_header,
@@ -145,23 +132,61 @@ pub(crate) async fn encrypt_core<T: StandardDocumentOps>(
     ))
 }
 
+pub(crate) async fn encrypt_core<T: StandardDocumentOps>(
+    standard_client: &T,
+    plaintext_document: PlaintextBytes,
+    metadata: &AlloyMetadata,
+) -> Result<EncryptedAttachedDocument, AlloyError> {
+    // In order to call the encrypt on standard, we need a map. This is just a hardcoded string we will
+    // use to encrypt.
+    let hardcoded_id = FieldId("".to_string());
+    let encrypted_document = standard_client
+        .encrypt(
+            PlaintextDocument(
+                [(hardcoded_id.clone(), plaintext_document)]
+                    .into_iter()
+                    .collect(),
+            ),
+            metadata,
+        )
+        .await?;
+    encrypted_document_to_attached(encrypted_document)
+}
+
 pub(crate) async fn encrypt_batch_core<T: StandardDocumentOps>(
     standard_client: &T,
     plaintext_documents: PlaintextAttachedDocuments,
     metadata: &AlloyMetadata,
 ) -> Result<StandardAttachedEncryptBatchResult, AlloyError> {
-    let attempts = join_all(plaintext_documents.into_iter().map(
-        |(document_id, plaintext_document)| {
-            encrypt_core(
-                standard_client,
-                PlaintextBytes(plaintext_document.0),
-                metadata,
-            )
-            .map(|encrypted_document| (document_id, encrypted_document))
-        },
-    ))
-    .await;
-    Ok(perform_batch_action(attempts, identity).into())
+    let hardcoded_field_id = FieldId("".to_string());
+    let plaintext_unattached_documents = PlaintextDocuments(
+        plaintext_documents
+            .into_iter()
+            .map(|(id, document)| {
+                (
+                    id,
+                    PlaintextDocument(
+                        [(hardcoded_field_id.clone(), PlaintextBytes(document.0))].into(),
+                    ),
+                )
+            })
+            .collect(),
+    );
+    let encrypted_batch = standard_client
+        .encrypt_batch(plaintext_unattached_documents, metadata)
+        .await?;
+    let reformed_documents =
+        perform_batch_action(encrypted_batch.successes, encrypted_document_to_attached);
+    let combined_failures = encrypted_batch
+        .failures
+        .into_iter()
+        .chain(reformed_documents.failures)
+        .collect();
+    Ok(BatchResult {
+        successes: reformed_documents.successes,
+        failures: combined_failures,
+    }
+    .into())
 }
 
 fn decode_edoc<T: StandardDocumentOps>(
@@ -174,7 +199,7 @@ fn decode_edoc<T: StandardDocumentOps>(
                 key_id_header: KeyIdHeader::new(
                     T::get_edek_type(),
                     T::get_payload_type(),
-                    KeyId(0),
+                    KeyId(0), // v5 can never use key ID of 0
                 ),
                 edek,
                 edoc,
@@ -218,23 +243,64 @@ pub(crate) async fn decrypt_core<T: StandardDocumentOps>(
     Ok(plaintext)
 }
 
+fn encrypted_attached_to_unattached<T: StandardDocumentOps>(
+    encrypted_document: EncryptedAttachedDocument,
+) -> Result<EncryptedDocument, AlloyError> {
+    let hardcoded_field_id = FieldId("".to_string());
+    let AttachedDocument {
+        key_id_header,
+        edek,
+        edoc,
+    } = decode_edoc::<T>(encrypted_document)?;
+    Ok(EncryptedDocument {
+        edek: EdekWithKeyIdHeader::new(key_id_header, edek),
+        document: [(
+            hardcoded_field_id.clone(),
+            EncryptedBytes(v5::EncryptedPayload::from(edoc).write_to_bytes()),
+        )]
+        .into_iter()
+        .collect(),
+    })
+}
+
 pub(crate) async fn decrypt_batch_core<T: StandardDocumentOps>(
     standard_client: &T,
     encrypted_documents: EncryptedAttachedDocuments,
     metadata: &AlloyMetadata,
 ) -> Result<StandardAttachedDecryptBatchResult, AlloyError> {
-    let attempts = join_all(encrypted_documents.into_iter().map(
-        |(document_id, encrypted_document)| {
-            decrypt_core(standard_client, encrypted_document, metadata).map(|decrypted_document| {
-                (
-                    document_id,
-                    decrypted_document.map(|x| PlaintextAttachedDocument(x.0)),
-                )
-            })
-        },
-    ))
-    .await;
-    Ok(perform_batch_action(attempts, identity).into())
+    let hardcoded_field_id = FieldId("".to_string());
+    let BatchResult {
+        successes: encrypted_unattached_documents,
+        failures: transform_failures,
+    } = perform_batch_action(encrypted_documents, encrypted_attached_to_unattached::<T>);
+    let decrypted_batch = standard_client
+        .decrypt_batch(EncryptedDocuments(encrypted_unattached_documents), metadata)
+        .await?;
+    let decrypted_attached = decrypted_batch
+        .successes
+        .into_iter()
+        .map(|(document_id, mut document)| {
+            (
+                document_id,
+                PlaintextAttachedDocument(
+                    document
+                        .0
+                        .remove(&hardcoded_field_id)
+                        .expect("Decryption doesn't change the structure of the fields.")
+                        .0,
+                ),
+            )
+        })
+        .collect();
+    let combined_failures = decrypted_batch
+        .failures
+        .into_iter()
+        .chain(transform_failures)
+        .collect();
+    Ok(StandardAttachedDecryptBatchResult {
+        successes: decrypted_attached,
+        failures: combined_failures,
+    })
 }
 
 pub(crate) async fn rekey_core<T: StandardDocumentOps>(
@@ -243,7 +309,7 @@ pub(crate) async fn rekey_core<T: StandardDocumentOps>(
     metadata: &AlloyMetadata,
     new_tenant_id: Option<TenantId>,
 ) -> Result<RekeyAttachedDocumentsBatchResult, AlloyError> {
-    let (edeks, mut edocs, decoding_errors) = encrypted_documents.into_iter().try_fold(
+    let (edeks, edocs, decoding_errors) = encrypted_documents.into_iter().try_fold(
         (HashMap::new(), HashMap::new(), HashMap::new()),
         |(mut edeks, mut edocs, mut failures), (document_id, attached_document)| {
             let maybe_attached_document = decode_edoc::<T>(attached_document);
@@ -270,10 +336,10 @@ pub(crate) async fn rekey_core<T: StandardDocumentOps>(
         .await?;
     let edeks_and_edocs = rekeyed_edeks
         .successes
-        .into_iter()
+        .into_par_iter()
         .map(|(document_id, edek)| {
-            let maybe_doc = edocs.remove(&document_id);
-            (document_id, (edek, maybe_doc))
+            let maybe_doc = edocs.get(&document_id);
+            (document_id, (edek, maybe_doc.cloned()))
         });
     let form_attached_document =
         |(rekeyed_edek, maybe_edoc): (EdekWithKeyIdHeader, Option<IvAndCiphertext>)| {

--- a/src/tenant_security_client/errors.rs
+++ b/src/tenant_security_client/errors.rs
@@ -36,6 +36,7 @@ pub enum KmsError {
     KmsConfigurationInvalid,
     KmsUnreachable,
     KmsThrottled,
+    KmsAccountIssue,
 }
 
 /// Errors related to security events
@@ -129,6 +130,7 @@ impl TenantSecurityProxyError {
                 KmsError::KmsConfigurationInvalid => 207,
                 KmsError::KmsUnreachable => 208,
                 KmsError::KmsThrottled => 209,
+                KmsError::KmsAccountIssue => 210,
             },
             Self::SecurityEvent { error, .. } => match error {
                 SecurityEventError::SecurityEventRejected => 301,
@@ -175,7 +177,8 @@ impl Display for KmsError {
             Self::KmsAuthorizationFailed => write!(f, "Request to KMS failed because the tenant credentials were invalid or have been revoked"),
             Self::KmsConfigurationInvalid => write!(f, "Request to KMS failed because the key configuration was invalid or the necessary permissions for the operation were missing/revoked"),
             Self::KmsUnreachable => write!(f, "Request to KMS failed because KMS was unreachable"),
-            Self::KmsThrottled => write!(f, "Request to KMS failed because KMS throttled the Tenant Security Proxy")
+            Self::KmsThrottled => write!(f, "Request to KMS failed because KMS throttled the Tenant Security Proxy"),
+            Self::KmsAccountIssue => write!(f, "Request to KMS failed because of an issue with the KMS account."),
         }
     }
 }

--- a/src/tenant_security_client/mod.rs
+++ b/src/tenant_security_client/mod.rs
@@ -26,7 +26,7 @@ mod request;
 mod rest;
 
 #[derive(Debug)]
-pub struct ApiKey(String);
+pub(crate) struct ApiKey(pub(crate) String);
 
 impl TryFrom<String> for ApiKey {
     type Error = AlloyError;
@@ -54,9 +54,9 @@ pub struct TenantSecurityClient {
 }
 
 impl TenantSecurityClient {
-    pub fn new(tsp_address: String, api_key: ApiKey, client: Client) -> TenantSecurityClient {
+    pub fn new(tsp_address: String, client: Client) -> TenantSecurityClient {
         TenantSecurityClient {
-            request: Arc::new(TspRequest::new(tsp_address, api_key, client)),
+            request: Arc::new(TspRequest::new(tsp_address, client)),
         }
     }
 

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -16,7 +16,10 @@ use ironcore_documents::{
 use itertools::Itertools;
 use rand::{CryptoRng, RngCore};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 use uniffi::custom_newtype;
 
 pub(crate) mod crypto;
@@ -205,7 +208,7 @@ pub(crate) fn encrypt_internal<R: RngCore + CryptoRng>(
     key_id: KeyId,
     edek_type: EdekType,
     plaintext_vector: PlaintextVector,
-    rng: &mut R,
+    rng: Arc<Mutex<R>>,
 ) -> Result<EncryptedVector, AlloyError> {
     let result = crypto::encrypt(
         key,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,8 +10,7 @@ use std::{
     process::{Command, ExitStatus, Stdio},
     sync::Arc,
 };
-use uniffi::TargetLanguage;
-use uniffi_bindgen::BindingGeneratorDefault;
+use uniffi_bindgen::BindingGenerator;
 
 pub type TestResult = Result<(), AlloyError>;
 
@@ -73,20 +72,17 @@ pub(crate) fn get_dynamic_library_paths() -> Result<Vec<PathBuf>, Box<dyn Error>
     Ok(paths)
 }
 
-pub(crate) fn generate_bindings(
+pub(crate) fn generate_bindings<T: BindingGenerator>(
     library_path: PathBuf,
     out_dir: PathBuf,
-    language: TargetLanguage,
+    language: T,
 ) -> Result<(), Box<dyn Error>> {
     let camino_lib_path = camino::Utf8PathBuf::from_path_buf(library_path).unwrap();
     let camino_out_dir = camino::Utf8PathBuf::from_path_buf(out_dir).unwrap();
     uniffi_bindgen::library_mode::generate_bindings(
         &camino_lib_path,
         None,
-        &BindingGeneratorDefault {
-            target_languages: vec![language],
-            try_format_code: false,
-        },
+        &language,
         None,
         &camino_out_dir,
         true,

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   tenant-security-proxy:
     env_file:

--- a/tests/foreign_tests_kotlin.rs
+++ b/tests/foreign_tests_kotlin.rs
@@ -32,7 +32,7 @@ mod test {
         generate_bindings(
             dynamic_library_paths[0].clone(),
             main_src_path,
-            uniffi::TargetLanguage::Kotlin,
+            uniffi::KotlinBindingGenerator,
         )?;
         // run the hatch test command and print the output as though it were our output
         let o = std::process::Command::new("./gradlew")

--- a/tests/foreign_tests_python.rs
+++ b/tests/foreign_tests_python.rs
@@ -29,7 +29,7 @@ mod test {
         generate_bindings(
             dynamic_library_paths[0].clone(),
             python_module_dir,
-            uniffi::TargetLanguage::Python,
+            uniffi::PythonBindingGenerator,
         )?;
         // run the hatch test command and print the output as though it were our output
         let o = Command::new("hatch")

--- a/tests/standard_attached.rs
+++ b/tests/standard_attached.rs
@@ -215,7 +215,6 @@ mod tests {
             .standard_attached()
             .rekey_documents(docs, &metadata, None)
             .await?;
-        dbg!(&all_rekeyed.failures);
         assert_eq!(all_rekeyed.successes.len(), 1);
         assert_eq!(all_rekeyed.failures.len(), 0);
         assert!(all_rekeyed


### PR DESCRIPTION
Lots of changes:
- Adds rayon, uses `into_par_iter()` to add parallelism to per-field and per-document computations
- Fix bug with standard EDEK parsing where V4 header variants weren't being created
- Some changes to Cargo.toml for binary size improvements
- Add additional check to standard decrypt, making sure that KeyIdHeader KeyId matches an Edek from V4DocumentHeader
- Fix several tests around document headers

Note that CI won't pass until the ironcore-documents PR merges