### PR TITLE
Fix remaining aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,47 +85,48 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -252,9 +253,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-serde"
@@ -390,9 +391,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 
 [[package]]
 name = "cfg-if"
@@ -490,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "convert_case"
@@ -639,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fnv"
@@ -801,9 +802,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
 dependencies = [
  "log",
  "plain",
@@ -1015,7 +1016,7 @@ dependencies = [
  "ascii85",
  "assertables",
  "async-trait",
- "base64 0.22.0",
+ "base64 0.22.1",
  "base64_type",
  "base85",
  "bytes",
@@ -1078,6 +1079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,9 +1125,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libm"
@@ -1605,7 +1612,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1694,7 +1701,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -1773,18 +1780,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1854,9 +1861,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2129,14 +2136,14 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "uniffi"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "anyhow",
  "camino",
@@ -2149,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "anyhow",
  "askama",
@@ -2173,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "quote",
  "syn",
@@ -2182,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2198,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "bincode",
  "camino",
@@ -2215,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2226,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "anyhow",
  "camino",
@@ -2238,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.27.1"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -2408,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs#cd489d4e04ce06d457cda8c2f13c1a5b907150f1"
+source = "git+https://github.com/mozilla/uniffi-rs#b79ede949cc5934c04aa13b17a662d9eda219edb"
 dependencies = [
  "nom",
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1713838472,
-        "narHash": "sha256-lCdDz6/YgyXdFRHall3P+dCETRpfz3Pi9eREnA9RX6k=",
+        "lastModified": 1714702555,
+        "narHash": "sha256-/NoUbE5S5xpK1FU3nlHhQ/tL126+JcisXdzy3Ng4pDU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "28a9436d356181603fb0d333565431c3d952f299",
+        "rev": "7f0e3ef7b7fbed78e12e5100851175d28af4b7c6",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 profile = "default"
-channel = "1.77.2"
+channel = "1.78.0"
 components = ["rust-src", "rust-analyzer", "llvm-tools"]

--- a/src/deterministic.rs
+++ b/src/deterministic.rs
@@ -25,11 +25,8 @@ pub struct PlaintextField {
 pub struct PlaintextFields(pub HashMap<FieldId, PlaintextField>);
 custom_newtype!(PlaintextFields, HashMap<FieldId, PlaintextField>);
 
-// TODO: These newtype can't include FieldId because of a bug with generated Python
-// not using forward references. If this is addressed, we can change it.
-// See https://github.com/mozilla/uniffi-rs/issues/2067
-pub struct EncryptedFields(pub HashMap<String, EncryptedField>);
-custom_newtype!(EncryptedFields, HashMap<String, EncryptedField>);
+pub struct EncryptedFields(pub HashMap<FieldId, EncryptedField>);
+custom_newtype!(EncryptedFields, HashMap<FieldId, EncryptedField>);
 pub struct GenerateFieldQueryResult(pub HashMap<FieldId, Vec<EncryptedField>>);
 custom_newtype!(GenerateFieldQueryResult, HashMap<FieldId, Vec<EncryptedField>>);
 create_batch_result_struct!(DeterministicRotateResult, EncryptedField, FieldId);

--- a/src/saas_shield/deterministic.rs
+++ b/src/saas_shield/deterministic.rs
@@ -12,11 +12,9 @@ use crate::deterministic::{
 use crate::errors::AlloyError;
 use crate::tenant_security_client::{DerivationType, SecretType, TenantSecurityClient};
 use crate::util::{check_rotation_no_op, perform_batch_action};
-use crate::FieldId;
 use crate::{alloy_client_trait::AlloyClient, AlloyMetadata, DerivationPath, SecretPath, TenantId};
 use ironcore_documents::v5::key_id_header::{EdekType, PayloadType};
 use itertools::Itertools;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -197,14 +195,7 @@ impl DeterministicFieldOps for SaasShieldDeterministicClient {
                 encrypted_field.derivation_path.clone(),
             )
         };
-        Ok(perform_batch_action(
-            encrypted_fields
-                .0
-                .into_par_iter()
-                .map(|(k, v)| (FieldId(k), v)),
-            decrypt_field,
-        )
-        .into())
+        Ok(perform_batch_action(encrypted_fields.0, decrypt_field).into())
     }
 
     /// Encrypt each plaintext field with any Current and InRotation keys for the provided secret path.
@@ -321,14 +312,7 @@ impl DeterministicFieldOps for SaasShieldDeterministicClient {
                 )
             }
         };
-        Ok(perform_batch_action(
-            encrypted_fields
-                .0
-                .into_par_iter()
-                .map(|(k, v)| (FieldId(k), v)),
-            reencrypt_field,
-        )
-        .into())
+        Ok(perform_batch_action(encrypted_fields.0, reencrypt_field).into())
     }
 
     /// Generate a prefix that could used to search a data store for fields encrypted using an identifier (KMS

--- a/src/saas_shield/mod.rs
+++ b/src/saas_shield/mod.rs
@@ -8,6 +8,7 @@ use convert_case::Casing;
 use ironcore_documents::v5::key_id_header::{EdekType, KeyId, KeyIdHeader, PayloadType};
 use itertools::Itertools;
 use std::collections::HashSet;
+use std::fmt::{Display, Formatter};
 
 pub mod config;
 pub mod deterministic;
@@ -35,15 +36,16 @@ pub enum SecurityEvent {
     Custom { event: CustomEvent },
 }
 
-impl ToString for SecurityEvent {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for SecurityEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
             SecurityEvent::Admin { event } => event.to_string(),
             SecurityEvent::Data { event } => event.to_string(),
             SecurityEvent::Periodic { event } => event.to_string(),
             SecurityEvent::User { event } => event.to_string(),
             SecurityEvent::Custom { event } => event.to_string(),
-        }
+        };
+        write!(f, "{str}")
     }
 }
 
@@ -55,9 +57,10 @@ pub enum AdminEvent {
     Remove,
 }
 
-impl ToString for AdminEvent {
-    fn to_string(&self) -> String {
-        format!("ADMIN_{:?}", self).to_case(convert_case::Case::ScreamingSnake)
+impl Display for AdminEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let formatted = format!("ADMIN_{:?}", self).to_case(convert_case::Case::ScreamingSnake);
+        write!(f, "{formatted}")
     }
 }
 
@@ -82,9 +85,10 @@ pub enum UserEvent {
     VerifyEmail,
 }
 
-impl ToString for UserEvent {
-    fn to_string(&self) -> String {
-        format!("USER_{:?}", self).to_case(convert_case::Case::ScreamingSnake)
+impl Display for UserEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let formatted = format!("USER_{:?}", self).to_case(convert_case::Case::ScreamingSnake);
+        write!(f, "{formatted}")
     }
 }
 
@@ -100,9 +104,10 @@ pub enum DataEvent {
     ChangePermissions,
 }
 
-impl ToString for DataEvent {
-    fn to_string(&self) -> String {
-        format!("DATA_{:?}", self).to_case(convert_case::Case::ScreamingSnake)
+impl Display for DataEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let formatted = format!("DATA_{:?}", self).to_case(convert_case::Case::ScreamingSnake);
+        write!(f, "{formatted}")
     }
 }
 
@@ -112,9 +117,10 @@ pub enum PeriodicEvent {
     CreateBackup,
 }
 
-impl ToString for PeriodicEvent {
-    fn to_string(&self) -> String {
-        format!("PERIODIC_{:?}", self).to_case(convert_case::Case::ScreamingSnake)
+impl Display for PeriodicEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let formatted = format!("PERIODIC_{:?}", self).to_case(convert_case::Case::ScreamingSnake);
+        write!(f, "{formatted}")
     }
 }
 
@@ -141,9 +147,9 @@ impl CustomEvent {
     }
 }
 
-impl ToString for CustomEvent {
-    fn to_string(&self) -> String {
-        format!("CUSTOM_{}", self.event_name,)
+impl Display for CustomEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CUSTOM_{}", self.event_name)
     }
 }
 

--- a/src/saas_shield/standard_attached.rs
+++ b/src/saas_shield/standard_attached.rs
@@ -38,12 +38,7 @@ impl StandardAttachedDocumentOps for SaasShieldStandardAttachedClient {
         plaintext_document: PlaintextAttachedDocument,
         metadata: &AlloyMetadata,
     ) -> Result<EncryptedAttachedDocument, AlloyError> {
-        encrypt_core(
-            &self.standard_client,
-            PlaintextBytes(plaintext_document.0),
-            metadata,
-        )
-        .await
+        encrypt_core(&self.standard_client, plaintext_document.0, metadata).await
     }
 
     /// Encrypt multiple documents with the provided metadata.
@@ -65,7 +60,7 @@ impl StandardAttachedDocumentOps for SaasShieldStandardAttachedClient {
     ) -> Result<PlaintextAttachedDocument, AlloyError> {
         decrypt_core(&self.standard_client, attached_document, metadata)
             .await
-            .map(|x| PlaintextAttachedDocument(x.0))
+            .map(|x| PlaintextAttachedDocument(PlaintextBytes(x.0)))
     }
 
     /// Decrypt multiple documents that were encrypted with the provided metadata.

--- a/src/saas_shield/vector.rs
+++ b/src/saas_shield/vector.rs
@@ -10,12 +10,11 @@ use crate::util::{check_rotation_no_op, perform_batch_action, OurReseedingRng};
 use crate::vector::{
     decrypt_internal, encrypt_internal, get_approximation_factor, EncryptedVector,
     EncryptedVectors, GenerateVectorQueryResult, PlaintextVector, PlaintextVectors,
-    VectorDecryptBatchResult, VectorEncryptBatchResult, VectorId, VectorOps, VectorRotateResult,
+    VectorDecryptBatchResult, VectorEncryptBatchResult, VectorOps, VectorRotateResult,
 };
 use crate::{AlloyMetadata, DerivationPath, SecretPath, TenantId, VectorEncryptionKey};
 use ironcore_documents::v5::key_id_header::{EdekType, KeyId, PayloadType};
 use itertools::Itertools;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -159,14 +158,7 @@ impl VectorOps for SaasShieldVectorClient {
                 self.rng.clone(),
             )
         };
-        Ok(perform_batch_action(
-            plaintext_vectors
-                .0
-                .into_par_iter()
-                .map(|(k, v)| (VectorId(k), v)),
-            encrypt_vector,
-        )
-        .into())
+        Ok(perform_batch_action(plaintext_vectors.0, encrypt_vector).into())
     }
 
     /// Decrypt a vector embedding that was encrypted with the provided metadata. The values of the embedding will
@@ -254,14 +246,7 @@ impl VectorOps for SaasShieldVectorClient {
                 icl_metadata_bytes,
             )
         };
-        Ok(perform_batch_action(
-            encrypted_vectors
-                .0
-                .into_par_iter()
-                .map(|(k, v)| (VectorId(k), v)),
-            decrypt_vector,
-        )
-        .into())
+        Ok(perform_batch_action(encrypted_vectors.0, decrypt_vector).into())
     }
 
     /// Encrypt each plaintext vector with any Current and InRotation keys for the provided secret path.

--- a/src/standalone/config.rs
+++ b/src/standalone/config.rs
@@ -63,7 +63,7 @@ impl StandardSecrets {
 
         // check that the provided primary does in fact exist
         if let Some(id) = primary_secret_id {
-            if internal_secrets.get(&(id as u32)).is_none() {
+            if !internal_secrets.contains_key(&(id as u32)) {
                 return Err(AlloyError::InvalidKey {
                     msg: format!("Primary secret id not found in provided secrets: {id}"),
                 });

--- a/src/standalone/deterministic.rs
+++ b/src/standalone/deterministic.rs
@@ -7,14 +7,12 @@ use crate::deterministic::{
 };
 use crate::errors::AlloyError;
 use crate::util::{check_rotation_no_op, perform_batch_action};
-use crate::FieldId;
 use crate::{
     alloy_client_trait::AlloyClient, AlloyMetadata, DerivationPath, SecretPath,
     StandaloneConfiguration, TenantId,
 };
 use ironcore_documents::v5::key_id_header::{EdekType, PayloadType};
 use itertools::Itertools;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -158,14 +156,7 @@ impl DeterministicFieldOps for StandaloneDeterministicClient {
         let decrypt_field = |encrypted_field: EncryptedField| {
             self.decrypt_sync(encrypted_field, &metadata.tenant_id)
         };
-        Ok(perform_batch_action(
-            encrypted_fields
-                .0
-                .into_par_iter()
-                .map(|(k, v)| (FieldId(k), v)),
-            decrypt_field,
-        )
-        .into())
+        Ok(perform_batch_action(encrypted_fields.0, decrypt_field).into())
     }
 
     /// Encrypt each plaintext field with any Current and InRotation keys for the provided secret path.
@@ -255,14 +246,7 @@ impl DeterministicFieldOps for StandaloneDeterministicClient {
                     })
             }
         };
-        Ok(perform_batch_action(
-            encrypted_fields
-                .0
-                .into_par_iter()
-                .map(|(k, v)| (FieldId(k), v)),
-            reencrypt_field,
-        )
-        .into())
+        Ok(perform_batch_action(encrypted_fields.0, reencrypt_field).into())
     }
 
     /// Generate a prefix that could used to search a data store for fields encrypted using an identifier (KMS

--- a/src/standalone/standard_attached.rs
+++ b/src/standalone/standard_attached.rs
@@ -35,12 +35,7 @@ impl StandardAttachedDocumentOps for StandaloneStandardAttachedClient {
         plaintext_document: PlaintextAttachedDocument,
         metadata: &AlloyMetadata,
     ) -> Result<EncryptedAttachedDocument, AlloyError> {
-        encrypt_core(
-            &self.standard_client,
-            PlaintextBytes(plaintext_document.0),
-            metadata,
-        )
-        .await
+        encrypt_core(&self.standard_client, plaintext_document.0, metadata).await
     }
 
     /// Encrypt multiple documents with the provided metadata.
@@ -62,7 +57,7 @@ impl StandardAttachedDocumentOps for StandaloneStandardAttachedClient {
     ) -> Result<PlaintextAttachedDocument, AlloyError> {
         decrypt_core(&self.standard_client, encrypted_document, metadata)
             .await
-            .map(|x| PlaintextAttachedDocument(x.0))
+            .map(|x| PlaintextAttachedDocument(PlaintextBytes(x.0)))
     }
 
     /// Decrypt multiple documents that were encrypted with the provided metadata.
@@ -160,7 +155,7 @@ mod test {
             .await
             .unwrap();
 
-        assert_eq!(result.0, vec![100u8; 400]);
+        assert_eq!(result.0, PlaintextBytes(vec![100u8; 400]));
     }
 
     #[tokio::test]
@@ -224,6 +219,6 @@ mod test {
             .await
             .unwrap();
         let result = client.decrypt(encrypted, &metadata).await.unwrap();
-        assert_eq!(result.0, plaintext);
+        assert_eq!(result.0 .0, plaintext);
     }
 }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -43,16 +43,13 @@ pub struct PlaintextVector {
     pub derivation_path: DerivationPath,
 }
 
-// TODO: These newtypes can't include VectorId because of a bug with generated Python
-// not using forward references. If this is addressed, we can change it.
-// See https://github.com/mozilla/uniffi-rs/issues/2067
-pub struct PlaintextVectors(pub HashMap<String, PlaintextVector>);
-custom_newtype!(PlaintextVectors, HashMap<String, PlaintextVector>);
-pub struct EncryptedVectors(pub HashMap<String, EncryptedVector>);
-custom_newtype!(EncryptedVectors, HashMap<String, EncryptedVector>);
-pub struct GenerateVectorQueryResult(pub HashMap<String, Vec<EncryptedVector>>);
-custom_newtype!(GenerateVectorQueryResult, HashMap<String, Vec<EncryptedVector>>);
-create_batch_result_struct!(VectorRotateResult, EncryptedVector, String);
+pub struct PlaintextVectors(pub HashMap<VectorId, PlaintextVector>);
+custom_newtype!(PlaintextVectors, HashMap<VectorId, PlaintextVector>);
+pub struct EncryptedVectors(pub HashMap<VectorId, EncryptedVector>);
+custom_newtype!(EncryptedVectors, HashMap<VectorId, EncryptedVector>);
+pub struct GenerateVectorQueryResult(pub HashMap<VectorId, Vec<EncryptedVector>>);
+custom_newtype!(GenerateVectorQueryResult, HashMap<VectorId, Vec<EncryptedVector>>);
+create_batch_result_struct!(VectorRotateResult, EncryptedVector, VectorId);
 
 create_batch_result_struct!(VectorEncryptBatchResult, EncryptedVector, VectorId);
 create_batch_result_struct!(VectorDecryptBatchResult, PlaintextVector, VectorId);

--- a/tests/deterministic.rs
+++ b/tests/deterministic.rs
@@ -93,8 +93,8 @@ mod tests {
             derivation_path: DerivationPath("deriv".to_string()),
         };
         let encrypted_fields = EncryptedFields(
-            iter::once(("bad_doc".to_string(), bad_encrypted))
-                .chain(encrypted.successes.into_iter().map(|(k, v)| (k.0, v)))
+            iter::once((FieldId("bad_doc".to_string()), bad_encrypted))
+                .chain(encrypted.successes)
                 .collect(),
         );
         let decrypted = get_client()
@@ -156,7 +156,7 @@ mod tests {
     #[tokio::test]
     async fn deterministic_rotate_fields_no_op() -> TestResult {
         let ciphertext = get_ciphertext();
-        let fields = EncryptedFields([("field".to_string(), ciphertext)].into());
+        let fields = EncryptedFields([(FieldId("field".to_string()), ciphertext)].into());
         let metadata = get_metadata();
         let mut resp = get_client()
             .deterministic()
@@ -182,7 +182,7 @@ mod tests {
     #[tokio::test]
     async fn deterministic_rotate_fields_new_tenant() -> TestResult {
         let ciphertext = get_ciphertext();
-        let fields = EncryptedFields([("field".to_string(), ciphertext)].into());
+        let fields = EncryptedFields([(FieldId("field".to_string()), ciphertext)].into());
         let metadata = get_metadata();
         let new_tenant_id = TenantId("tenant-aws-l".to_string());
         let mut resp = get_client()

--- a/tests/standard.rs
+++ b/tests/standard.rs
@@ -80,7 +80,7 @@ mod tests {
         ]);
         let doc_bytes = [(FieldId("doc".to_string()), doc)].into();
         EncryptedDocument {
-            edek: EdekWithKeyIdHeader(edek_bytes.0),
+            edek: EdekWithKeyIdHeader(EncryptedBytes(edek_bytes.0)),
             document: doc_bytes,
         }
     }
@@ -93,7 +93,7 @@ mod tests {
             .standard()
             .encrypt(plaintext, &metadata)
             .await?;
-        assert_eq!(encrypted.edek.0.len(), 259);
+        assert_eq!(encrypted.edek.0 .0.len(), 259);
         Ok(())
     }
 
@@ -265,7 +265,7 @@ mod tests {
             .standard()
             .encrypt_with_existing_edek(plaintext_with_edek, &metadata)
             .await?;
-        assert_eq!(encrypted.edek.0, edek_bytes);
+        assert_eq!(encrypted.edek.0 .0, edek_bytes);
         let decrypted = get_client()
             .standard()
             .decrypt(encrypted, &metadata)
@@ -357,7 +357,7 @@ mod tests {
             .get(&DocumentId("edek".to_string()))
             .unwrap();
         // First 4 bytes are KMS config ID 511
-        assert!(rekeyed.0.starts_with(&[0, 0, 1, 255, 2, 0]));
+        assert!(rekeyed.0 .0.starts_with(&[0, 0, 1, 255, 2, 0]));
         Ok(())
     }
 
@@ -385,7 +385,7 @@ mod tests {
             .unwrap();
         // This is now a V5 document, which starts with the KeyIdHeader
         // First 4 bytes are KMS config ID 511
-        assert!(rekeyed.0.starts_with(&[0, 0, 1, 255, 2, 0]));
+        assert!(rekeyed.0 .0.starts_with(&[0, 0, 1, 255, 2, 0]));
         Ok(())
     }
 


### PR DESCRIPTION
Consumes latest uniffi, fixing issue with generating aliases. Also updates to Rust 1.78.0 and fixes new clippy lints it brings