### PR TITLE
Add links to other benches from `benches`

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -83,3 +83,7 @@ Since ironcore-alloy is a library that interacts with a back-end service (TSP), 
 In general, operation latency is a function of latency to the TSP + latency to the tenant's KMS (if key-leasing is disabled).
 
 The TSP's tenant logging mechanism has some tunable limits. By default, a TSP should be able to sustain 500 ops/sec/tenant, with the ability to burst higher for a limited time. The benchmark is using a single tenant, and (depending on your machine and benchmark config) can easily be executing a few thousand ops/sec. If you run a benchmark long enough you will overwhelm the TSP. In a real application, you would scale-out the TSP at this point. See [the TSP documentation](https://ironcorelabs.com/docs/saas-shield/tenant-security-proxy/deployment/) for more details.
+
+## Other Languages
+
+There are also benchmarks available in [Kotlin](https://github.com/IronCoreLabs/ironcore-alloy/tree/main/kotlin/benchmarks/src) and [Python](https://github.com/IronCoreLabs/ironcore-alloy/blob/main/python/ironcore-alloy/bench.py).

--- a/kotlin/benchmarks/src/README.md
+++ b/kotlin/benchmarks/src/README.md
@@ -77,3 +77,7 @@ Since ironcore-alloy is a library that interacts with a back-end service (TSP), 
 In general, operation latency is a function of latency to the TSP + latency to the tenant's KMS (if key-leasing is disabled).
 
 The benchmark is using a single tenant, and (depending on your machine and benchmark config) can easily be executing a few thousand ops/sec. If you run the benchmark long enough you can overwhelm the TSP. In a real application, you would scale-out the TSP at this point. See [the TSP documentation](https://ironcorelabs.com/docs/saas-shield/tenant-security-proxy/deployment/) for more details.
+
+## Other Languages
+
+There are also benchmarks available in [Rust](https://github.com/IronCoreLabs/ironcore-alloy/tree/main/benches) and [Python](https://github.com/IronCoreLabs/ironcore-alloy/blob/main/python/ironcore-alloy/bench.py).


### PR DESCRIPTION
The README explains the top level `benches` are Rust ones, this adds links to find the other benches, since each of them has different folder structure and naming.