### PR TITLE
Update example-integrations to ironcore-alloy v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes:
 - Reworked several type aliases into newtype structs. In Rust this will require creating structs, but Python and Kotlin are unaffected.
 - Renamed `StandaloneAttachedStandardClient` to `StandaloneStandardAttachedClient`.
 - Changed Standard Attached `get_searchable_edek_prefix` to be synchronous.
+- Changed several constructors to require keyword arguments.
 
 Other changes:
 

--- a/example-integrations/elasticsearch/pyproject.toml
+++ b/example-integrations/elasticsearch/pyproject.toml
@@ -3,9 +3,9 @@
 [project]
 name = "elasticsearch-example"
 authors = [{ name = "IronCore Labs", email = "info@ironcorelabs.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "ironcore-alloy>=0.10.3,<0.11",
+    "ironcore-alloy>=0.11.2,<0.12",
     "elasticsearch==8.12.0",
     "sentence_transformers==2.3.1",
 ]

--- a/example-integrations/milvus/milvus-semantic-search.py
+++ b/example-integrations/milvus/milvus-semantic-search.py
@@ -28,7 +28,7 @@ async def display_results(
         decrypted_question = await alloy_client.standard_attached().decrypt(
             recreated_question, metadata
         )
-        recreated_round = alloy.EncryptedField(base64.b64decode(result.entity.get("round")), secret_path, derivation_path)  # type: ignore
+        recreated_round = alloy.EncryptedField(encrypted_field=base64.b64decode(result.entity.get("round")), secret_path=secret_path, derivation_path=derivation_path)  # type: ignore
         # We have to deterministically decrypt the round because it was deterministically encrypted earlier
         decrypted_round = await alloy_client.deterministic().decrypt(
             recreated_round, metadata
@@ -103,7 +103,9 @@ async def main():
         question_emb = model.encode(row["Question"]).tolist()  # type: ignore
         # each index and set of vectors is encrypted with different derived keys
         plaintext_vector = alloy.PlaintextVector(
-            question_emb, secret_path, derivation_path
+            plaintext_vector=question_emb,
+            secret_path=secret_path,
+            derivation_path=derivation_path,
         )
         # Some questions contain HTML tags that muddle the results, so we'll skip inserting those ones
         if "<" in row["Question"]:
@@ -117,7 +119,9 @@ async def main():
             ),
             alloy_client.deterministic().encrypt(
                 alloy.PlaintextField(
-                    bytes(row["Round"], "utf-8"), secret_path, derivation_path
+                    plaintext_field=bytes(row["Round"], "utf-8"),
+                    secret_path=secret_path,
+                    derivation_path=derivation_path,
                 ),
                 metadata,
             ),
@@ -137,7 +141,11 @@ async def main():
 
     # Create the query embedding
     query_emb = model.encode(query).tolist()  # type: ignore
-    plaintext_query = alloy.PlaintextVector(query_emb, secret_path, derivation_path)
+    plaintext_query = alloy.PlaintextVector(
+        plaintext_vector=query_emb,
+        secret_path=secret_path,
+        derivation_path=derivation_path,
+    )
     # `generate_query_vectors` returns a list because the secret involved may be in rotation. In that case you should
     # search for both resulting vectors.
     query_vector = (
@@ -168,7 +176,9 @@ async def main():
     # Now we'll query a second time, only returning answers from the Double Jeopardy round
     round_filter = await alloy_client.deterministic().encrypt(
         alloy.PlaintextField(
-            bytes("Double Jeopardy!", "utf-8"), secret_path, derivation_path
+            plaintext_field=bytes("Double Jeopardy!", "utf-8"),
+            secret_path=secret_path,
+            derivation_path=derivation_path,
         ),
         metadata,
     )

--- a/example-integrations/milvus/pyproject.toml
+++ b/example-integrations/milvus/pyproject.toml
@@ -3,9 +3,9 @@
 [project]
 name = "milvus-example"
 authors = [{ name = "IronCore Labs", email = "info@ironcorelabs.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "ironcore-alloy>=0.10.3,<0.11",
+    "ironcore-alloy>=0.11.2,<0.12",
     "sentence_transformers==2.3.1",
     "pymilvus==2.3.7",
 ]

--- a/example-integrations/opensearch/opensearch-cloaked-hybrid-search.py
+++ b/example-integrations/opensearch/opensearch-cloaked-hybrid-search.py
@@ -101,7 +101,12 @@ async def main():
         title_embedding = model.encode(book["title"]).tolist()
         # Encrypt the title embedding with IronCore Labs' Cloaked AI
         encrypted_title_embedding = await sdk.vector().encrypt(
-            alloy.PlaintextVector(title_embedding, "book_index", ""), metadata
+            alloy.PlaintextVector(
+                plaintext_vector=title_embedding,
+                secret_path="book_index",
+                derivation_path="",
+            ),
+            metadata,
         )
         operations.append({"index": {"_index": "book_index"}})
         book["title_vector"] = encrypted_title_embedding.encrypted_vector
@@ -113,7 +118,13 @@ async def main():
     title_query_embedding = model.encode("python programming").tolist()
     # `generate_query_vectors` returns a list because the secret involved may be in rotation.
     encrypted_title_query_embeddings = await sdk.vector().generate_query_vectors(
-        {"title": alloy.PlaintextVector(title_query_embedding, "book_index", "")},
+        {
+            "title": alloy.PlaintextVector(
+                plaintext_vector=title_query_embedding,
+                secret_path="book_index",
+                derivation_path="",
+            )
+        },
         metadata,
     )
     embedding_queries = [

--- a/example-integrations/opensearch/pyproject.toml
+++ b/example-integrations/opensearch/pyproject.toml
@@ -3,9 +3,9 @@
 [project]
 name = "opensearch-example"
 authors = [{ name = "IronCore Labs", email = "info@ironcorelabs.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "ironcore-alloy>=0.10.3,<0.11",
+    "ironcore-alloy>=0.11.2,<0.12",
     "opensearch-py==2.4.2",
     "sentence_transformers==2.3.1",
 ]

--- a/example-integrations/pgvector/pgvector-semantic-search.py
+++ b/example-integrations/pgvector/pgvector-semantic-search.py
@@ -22,7 +22,7 @@ async def display_results(
         decrypted_question = await alloy_client.standard_attached().decrypt(
             recreated_question, metadata
         )
-        recreated_round = alloy.EncryptedField(base64.b64decode(round_str), secret_path, derivation_path)  # type: ignore
+        recreated_round = alloy.EncryptedField(encrypted_field=base64.b64decode(round_str), secret_path=secret_path, derivation_path=derivation_path)  # type: ignore
         # We have to deterministically decrypt the round because it was deterministically encrypted earlier
         decrypted_round = await alloy_client.deterministic().decrypt(
             recreated_round, metadata
@@ -72,7 +72,9 @@ async def main():
         question_emb = model.encode(row["Question"]).tolist()  # type: ignore
         # each index and set of vectors is encrypted with different derived keys
         plaintext_vector = alloy.PlaintextVector(
-            question_emb, secret_path, derivation_path
+            plaintext_vector=question_emb,
+            secret_path=secret_path,
+            derivation_path=derivation_path,
         )
         # Some questions contain HTML tags that muddle the results, so we'll skip inserting those ones
         if "<" in row["Question"]:
@@ -86,7 +88,9 @@ async def main():
             ),
             alloy_client.deterministic().encrypt(
                 alloy.PlaintextField(
-                    bytes(row["Round"], "utf-8"), secret_path, derivation_path
+                    plaintext_field=bytes(row["Round"], "utf-8"),
+                    secret_path=secret_path,
+                    derivation_path=derivation_path,
                 ),
                 metadata,
             ),
@@ -110,7 +114,11 @@ async def main():
 
     # Create the query embedding
     query_emb = model.encode(query).tolist()  # type: ignore
-    plaintext_query = alloy.PlaintextVector(query_emb, secret_path, derivation_path)
+    plaintext_query = alloy.PlaintextVector(
+        plaintext_vector=query_emb,
+        secret_path=secret_path,
+        derivation_path=derivation_path,
+    )
     # `generate_query_vectors` returns a list because the secret involved may be in rotation. In that case you should
     # search for both resulting vectors.
     query_vector = (
@@ -131,7 +139,9 @@ async def main():
     # Now we'll query a second time, only returning answers from the Double Jeopardy round
     round_filter = await alloy_client.deterministic().encrypt(
         alloy.PlaintextField(
-            bytes("Double Jeopardy!", "utf-8"), secret_path, derivation_path
+            plaintext_field=bytes("Double Jeopardy!", "utf-8"),
+            secret_path=secret_path,
+            derivation_path=derivation_path,
         ),
         metadata,
     )

--- a/example-integrations/pgvector/pyproject.toml
+++ b/example-integrations/pgvector/pyproject.toml
@@ -3,9 +3,9 @@
 [project]
 name = "pgvector-example"
 authors = [{ name = "IronCore Labs", email = "info@ironcorelabs.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "ironcore-alloy>=0.10.3,<0.11",
+    "ironcore-alloy>=0.11.2,<0.12",
     "sentence_transformers==2.3.1",
     "pgvector==0.2.5",
     "asyncpg==0.29.0",

--- a/example-integrations/pinecone/pyproject.toml
+++ b/example-integrations/pinecone/pyproject.toml
@@ -3,9 +3,9 @@
 [project]
 name = "pinecone-example"
 authors = [{ name = "IronCore Labs", email = "info@ironcorelabs.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "ironcore-alloy>=0.10.3,<0.11",
+    "ironcore-alloy>=0.11.2,<0.12",
     "sentence_transformers==2.3.1",
     "pinecone-client[grpc]==2.2.4",
     "pinecone-datasets==0.6.2",

--- a/example-integrations/weaviate/pyproject.toml
+++ b/example-integrations/weaviate/pyproject.toml
@@ -3,9 +3,9 @@
 [project]
 name = "weaviate-example"
 authors = [{ name = "IronCore Labs", email = "info@ironcorelabs.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "ironcore-alloy>=0.10.3,<0.11",
+    "ironcore-alloy>=0.11.2,<0.12",
     "weaviate_client==4.4.0",
     "sentence_transformers==2.3.1",
     "pydantic==2.6.1",


### PR DESCRIPTION
The `example-integrations` were still written for ironcore-alloy v0.10.x. The `examples` had already been updated.