### PR TITLE
Update benchmarks for all languages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1740536993,
-        "narHash": "sha256-3YI+1ONZ28chM19Hep9Z+TSyiybYf/1VC/gwImVZKUw=",
+        "lastModified": 1742783666,
+        "narHash": "sha256-IwdSl51NL6V0f+mYXZR0UTKaGleOsk9zV3l6kt5SUWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9f05c0655de9dc2c7b60b689447c48abb9190bf8",
+        "rev": "60766d63c227d576510ecfb5edd3a687d56f6bc7",
         "type": "github"
       },
       "original": {

--- a/java/src/jmh/java/com/ironcorelabs/ironcore_alloy_java/README.md
+++ b/java/src/jmh/java/com/ironcorelabs/ironcore_alloy_java/README.md
@@ -83,20 +83,20 @@ The benchmark is using a single tenant, and (depending on your machine and bench
 
 There are also benchmarks available in [Rust](https://github.com/IronCoreLabs/ironcore-alloy/tree/main/benches), [Kotlin](https://github.com/IronCoreLabs/ironcore-alloy/tree/main/kotlin/benchmarks) and [Python](https://github.com/IronCoreLabs/ironcore-alloy/blob/main/python/ironcore-alloy/bench.py).
 
-The following were benchmarks run on 8/15/2024 on a Macbook M1 Max.
+The following were benchmarks run on March 24th, 2025 on a Macbook M2 Max.
 
 ```text
 Benchmark                                             Mode  Cnt       Score       Error  Units
-SaasShieldBenchmark.batchEncrypt10DocsOf100B          avgt    5    3880.803 ±   373.629  us/op
-SaasShieldBenchmark.tspDecrypt100B                    avgt    5     899.365 ±   151.952  us/op
-SaasShieldBenchmark.tspDecrypt10KB                    avgt    5    6204.417 ±   804.504  us/op
-SaasShieldBenchmark.tspDecrypt1B                      avgt    5     753.186 ±    53.981  us/op
-SaasShieldBenchmark.tspDecrypt1MB                     avgt    5  344116.886 ± 11127.442  us/op
-SaasShieldBenchmark.tspEncrypt100B                    avgt    5     919.766 ±   249.134  us/op
-SaasShieldBenchmark.tspEncrypt10KB                    avgt    5    6705.966 ±   646.834  us/op
-SaasShieldBenchmark.tspEncrypt1B                      avgt    5    1211.361 ±   900.329  us/op
-SaasShieldBenchmark.tspEncrypt1MB                     avgt    5  340480.214 ±  6824.536  us/op
-StandaloneBenchmark.standaloneRoundtripStandard100Kb  avgt    5     525.981 ±   169.361  us/op
-StandaloneBenchmark.standaloneRoundtripStandard10B    avgt    5     427.260 ±   164.509  us/op
-StandaloneBenchmark.standaloneRoundtripStandard10Kb   avgt    5     445.747 ±   161.576  us/op
+SaasShieldBenchmark.batchEncrypt10DocsOf100B          avgt    5   1004.374 ± 176.667  us/op
+SaasShieldBenchmark.tspDecrypt100B                    avgt    5    309.908 ±  58.527  us/op
+SaasShieldBenchmark.tspDecrypt10KB                    avgt    5    492.581 ± 183.462  us/op
+SaasShieldBenchmark.tspDecrypt1B                      avgt    5    299.011 ±  15.632  us/op
+SaasShieldBenchmark.tspDecrypt1MB                     avgt    5  11287.560 ± 235.532  us/op
+SaasShieldBenchmark.tspEncrypt100B                    avgt    5    303.053 ±  37.513  us/op
+SaasShieldBenchmark.tspEncrypt10KB                    avgt    5    458.719 ±  85.330  us/op
+SaasShieldBenchmark.tspEncrypt1B                      avgt    5    299.640 ±  39.078  us/op
+SaasShieldBenchmark.tspEncrypt1MB                     avgt    5  11580.426 ± 575.643  us/op
+StandaloneBenchmark.standaloneRoundtripStandard100Kb  avgt    5   2177.326 ±  83.221  us/op
+StandaloneBenchmark.standaloneRoundtripStandard10B    avgt    5    133.866 ±  50.676  us/op
+StandaloneBenchmark.standaloneRoundtripStandard10Kb   avgt    5    337.769 ±  49.548  us/op
 ```

--- a/java/src/jmh/java/com/ironcorelabs/ironcore_alloy_java/StandaloneBenchmark.java
+++ b/java/src/jmh/java/com/ironcorelabs/ironcore_alloy_java/StandaloneBenchmark.java
@@ -54,9 +54,9 @@ public class StandaloneBenchmark {
 
         standaloneConfig = new StandaloneConfiguration(standardSecrets, deterministicSecrets, vectorSecrets);
         standaloneSdk = new Standalone(standaloneConfig);
-        smallWord = new PlaintextBytes(randomWord(1).getBytes());
-        mediumWord = new PlaintextBytes(randomWord(10).getBytes());
-        largeWord = new PlaintextBytes(randomWord(100).getBytes());
+        smallWord = new PlaintextBytes(randomWord(10).getBytes());
+        mediumWord = new PlaintextBytes(randomWord(10 * 1000).getBytes());
+        largeWord = new PlaintextBytes(randomWord(100 * 1000).getBytes());
     }
 
     private String randomWord(int length) {

--- a/kotlin/benchmarks/src/README.md
+++ b/kotlin/benchmarks/src/README.md
@@ -84,20 +84,21 @@ There are also benchmarks available in [Rust](https://github.com/IronCoreLabs/ir
 
 ## Results
 
-The following benchmarking run was done on May 7, 2024 on a MacBook Pro (2023) with an Apple M2 Max chip. It uses a locally-built TSP running with the configuration from `demo-tsp.conf`.
+The following benchmarking run was done on March 24th, 2025 on a Macbook M2 Max.
 
-```
+```text
 Benchmark                                             Mode  Cnt     Score     Error  Units
-SaasShieldBenchmark.batchEncrypt10DocsOf100B          avgt    5   545.626 ±  19.272  us/op
-SaasShieldBenchmark.tspDecrypt100B                    avgt    5   148.846 ±  11.811  us/op
-SaasShieldBenchmark.tspDecrypt10KB                    avgt    5   242.892 ±   2.902  us/op
-SaasShieldBenchmark.tspDecrypt1B                      avgt    5   141.517 ±   7.603  us/op
-SaasShieldBenchmark.tspDecrypt1MB                     avgt    5  9104.683 ±  74.820  us/op
-SaasShieldBenchmark.tspEncrypt100B                    avgt    5   142.432 ±   5.696  us/op
-SaasShieldBenchmark.tspEncrypt10KB                    avgt    5   246.627 ±   5.616  us/op
-SaasShieldBenchmark.tspEncrypt1B                      avgt    5   139.817 ±   5.732  us/op
-SaasShieldBenchmark.tspEncrypt1MB                     avgt    5  9322.918 ± 136.650  us/op
-StandaloneBenchmark.standaloneRoundtripStandard100Kb  avgt    5   117.444 ±  56.447  us/op
-StandaloneBenchmark.standaloneRoundtripStandard10B    avgt    5   112.489 ±  56.958  us/op
-StandaloneBenchmark.standaloneRoundtripStandard10Kb   avgt    5   113.051 ±  51.750  us/op
+SaasShieldBenchmark.batchEncrypt10DocsOf100B          avgt    5    972.373 ±   81.365  us/op
+SaasShieldBenchmark.tspDecrypt100B                    avgt    5    300.325 ±   18.856  us/op
+SaasShieldBenchmark.tspDecrypt10KB                    avgt    5    422.159 ±   55.192  us/op
+SaasShieldBenchmark.tspDecrypt1B                      avgt    5    290.425 ±   20.535  us/op
+SaasShieldBenchmark.tspDecrypt1MB                     avgt    5  11429.166 ±  206.175  us/op
+SaasShieldBenchmark.tspEncrypt100B                    avgt    5    292.691 ±   19.519  us/op
+SaasShieldBenchmark.tspEncrypt10KB                    avgt    5    414.124 ±   45.703  us/op
+SaasShieldBenchmark.tspEncrypt1B                      avgt    5    292.419 ±   19.750  us/op
+SaasShieldBenchmark.tspEncrypt1MB                     avgt    5  11721.616 ± 1013.550  us/op
+StandaloneBenchmark.standaloneRoundtripStandard100Kb  avgt    5   2177.714 ±   85.201  us/op
+StandaloneBenchmark.standaloneRoundtripStandard10B    avgt    5    127.618 ±   70.516  us/op
+StandaloneBenchmark.standaloneRoundtripStandard10Kb   avgt    5    328.130 ±   98.322  us/op
+StandaloneBenchmark.standaloneVectorEncrypt384d       avgt    5     80.240 ±   38.963  us/op
 ```

--- a/kotlin/benchmarks/src/StandaloneBenchmark.kt
+++ b/kotlin/benchmarks/src/StandaloneBenchmark.kt
@@ -2,8 +2,8 @@ package test
 
 import com.ironcorelabs.ironcore_alloy.*
 import java.util.Base64
-import java.util.concurrent.*
 import java.util.Random
+import java.util.concurrent.*
 import kotlin.ByteArray
 import kotlin.system.*
 import kotlinx.coroutines.*
@@ -58,9 +58,9 @@ class StandaloneBenchmark {
 
     @Setup
     fun setUp() {
-        smallWord = randomWord(1).toByteArray()
-        mediumWord = randomWord(10).toByteArray()
-        largeWord = randomWord(100).toByteArray()
+        smallWord = randomWord(10).toByteArray()
+        mediumWord = randomWord(10 * 1000).toByteArray()
+        largeWord = randomWord(100 * 1000).toByteArray()
     }
 
     @State(Scope.Thread)
@@ -70,9 +70,7 @@ class StandaloneBenchmark {
 
     @Benchmark
     fun standaloneVectorEncrypt384d(s: Vector384State) {
-        runBlocking {
-            standaloneSdk.vector().encrypt(PlaintextVector(s.vector, "", ""), metadata)
-        }
+        runBlocking { standaloneSdk.vector().encrypt(PlaintextVector(s.vector, "", ""), metadata) }
     }
 
     @Benchmark

--- a/python/ironcore-alloy/BENCHMARKS.md
+++ b/python/ironcore-alloy/BENCHMARKS.md
@@ -18,7 +18,7 @@ vector encrypt d=1536: Mean +- std dev: 4.00 ms +- 0.05 ms
 vector encrypt d=2048: Mean +- std dev: 5.26 ms +- 0.06 ms
 vector batch (100) encrypt d=768: Mean +- std dev: 192 ms +- 2 ms
 vector batch (1000) encrypt d=768: Mean +- std dev: 1.91 sec +- 0.01 sec
-standard_roundtrip_small: Mean +- std dev: 178 us +- 12 us
-standard_roundtrip_medium: Mean +- std dev: 3.75 ms +- 0.05 ms
-standard_roundtrip_large: Mean +- std dev: 35.2 ms +- 0.4 ms
+standard_roundtrip_10b: Mean +- std dev: 178 us +- 12 us
+standard_roundtrip_10kb: Mean +- std dev: 3.75 ms +- 0.05 ms
+standard_roundtrip_100kb: Mean +- std dev: 35.2 ms +- 0.4 ms
 ```

--- a/python/ironcore-alloy/BENCHMARKS.md
+++ b/python/ironcore-alloy/BENCHMARKS.md
@@ -9,25 +9,16 @@ See `project_root/benches/README.md` for more general information about benchmar
 
 ## Results
 
-The following benchmarking run was done on August 30th, 2024 on a Lenovo Thinkpad X1 Extreme 2nd Gen with an i9-9880H CPU.
+The following benchmarking run was done on March 24th, 2025 on a Macbook M2 Max.
 
-```
-.....................
-vector encrypt d=384: Mean +- std dev: 2.66 ms +- 0.14 ms
-.....................
-vector encrypt d=768: Mean +- std dev: 5.28 ms +- 0.25 ms
-.....................
-vector encrypt d=1536: Mean +- std dev: 10.3 ms +- 0.6 ms
-.....................
-vector encrypt d=2048: Mean +- std dev: 13.6 ms +- 0.7 ms
-.....................
-vector batch (100) encrypt d=768: Mean +- std dev: 416 ms +- 25 ms
-.....................
-vector batch (1000) encrypt d=768: Mean +- std dev: 4.14 sec +- 0.19 sec
-.....................
-standard_roundtrip_small: Mean +- std dev: 616 us +- 23 us
-.....................
-standard_roundtrip_medium: Mean +- std dev: 13.1 ms +- 0.6 ms
-.....................
-standard_roundtrip_large: Mean +- std dev: 124 ms +- 6 ms 
+```text
+vector encrypt d=384: Mean +- std dev: 1.07 ms +- 0.02 ms
+vector encrypt d=768: Mean +- std dev: 2.07 ms +- 0.05 ms
+vector encrypt d=1536: Mean +- std dev: 4.00 ms +- 0.05 ms
+vector encrypt d=2048: Mean +- std dev: 5.26 ms +- 0.06 ms
+vector batch (100) encrypt d=768: Mean +- std dev: 192 ms +- 2 ms
+vector batch (1000) encrypt d=768: Mean +- std dev: 1.91 sec +- 0.01 sec
+standard_roundtrip_small: Mean +- std dev: 178 us +- 12 us
+standard_roundtrip_medium: Mean +- std dev: 3.75 ms +- 0.05 ms
+standard_roundtrip_large: Mean +- std dev: 35.2 ms +- 0.4 ms
 ```

--- a/python/ironcore-alloy/bench.py
+++ b/python/ironcore-alloy/bench.py
@@ -144,7 +144,7 @@ runner.bench_async_func(
 ### standalone standard
 random_small_word = random_word(10).encode("utf-8")
 runner.bench_async_func(
-    "standard_roundtrip_small",
+    "standard_roundtrip_10b",
     standard_roundtrip,
     sdk,
     random_small_word,
@@ -152,9 +152,9 @@ runner.bench_async_func(
 )
 random_medium_word = random_word(10 * 1000).encode("utf-8")
 runner.bench_async_func(
-    "standard_roundtrip_medium", standard_roundtrip, sdk, random_medium_word, metadata
+    "standard_roundtrip_10kb", standard_roundtrip, sdk, random_medium_word, metadata
 )
-random_large_word = random_word(10 * 10000).encode("utf-8")
+random_large_word = random_word(100 * 1000).encode("utf-8")
 runner.bench_async_func(
-    "standard_roundtrip_large", standard_roundtrip, sdk, random_large_word, metadata
+    "standard_roundtrip_100kb", standard_roundtrip, sdk, random_large_word, metadata
 )


### PR DESCRIPTION
- Ran benchmarks for all languages
- Fixed Kotlin/Java benchmarks, which incorrectly indicated data size for some tests
- Updated the flake (hatch works again)

Notes:
- Python numbers are much faster than before
- Kotlin numbers are much slower than before. This is because the original benchmarks used a fully-local TSP instead of the Docker container
- Java and Kotlin numbers are slower for `standaloneRoundtripStandard*` tests because they were actually using 1/10/100 bytes instead of their indicated 10b/10kb/100kb.