### PR TITLE
Update to use the Portal OSSRH Staging API

### DIFF
--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -48,7 +48,7 @@ jobs:
         run: cargo run --bin uniffi-bindgen generate --library resources/linux-x86-64/libironcore_alloy.so --language kotlin --out-dir kotlin
         working-directory: kotlin/src/main
       - name: Publish
-        run: ./gradlew publish
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         working-directory: kotlin
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -91,7 +91,7 @@ jobs:
         run: cargo run --bin uniffi-bindgen-java generate --library resources/linux-x86-64/libironcore_alloy.so --out-dir java
         working-directory: java/src/main
       - name: Publish
-        run: ./gradlew publish
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         working-directory: java
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -35,7 +35,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 }
 
-nexusPublishing { repositories { sonatype() } }
+// Until there is official support, we can use the Portal OSSRH Staging API.
+// See https://central.sonatype.org/publish/publish-portal-gradle/
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
+    }
+}
 
 publishing {
     publications {
@@ -88,4 +97,4 @@ signing {
     useGpgCmd()
     sign(publishing.publications["mavenJava"])
 }
-   
+

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -70,7 +70,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-nexusPublishing { repositories { sonatype() } }
+// Until there is official support, we can use the Portal OSSRH Staging API.
+// See https://central.sonatype.org/publish/publish-portal-gradle/
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
+    }
+}
 
 publishing {
     publications {


### PR DESCRIPTION
This doesn't upgrade to completely use [Central Portal](https://central.sonatype.org/publish/publish-portal-guide), but does upgrade to use the [portal staging api](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) which is basically a way to use older plugins even after the sunset date.