### PR TITLE
Cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,9 +515,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1057,6 +1057,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1766,9 +1777,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
@@ -2202,15 +2213,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/benches/ironcore_alloy_bench.rs
+++ b/benches/ironcore_alloy_bench.rs
@@ -355,7 +355,7 @@ fn tsp_benches(c: &mut Criterion) {
                 let field_size = 10;
                 PlaintextDocuments((0..num_documents).fold(HashMap::new(), |mut acc, i| {
                     let doc = generate_plaintext(field_size, num_fields, &mut rng);
-                    acc.insert(DocumentId(format!("doc{}", i)), doc);
+                    acc.insert(DocumentId(format!("doc{i}")), doc);
                     acc
                 }))
             },
@@ -377,7 +377,7 @@ fn generate_plaintext(
 ) -> PlaintextDocument {
     PlaintextDocument((0..num_fields).fold(HashMap::new(), |mut acc, i| {
         acc.insert(
-            FieldId(format!("field{}", i)),
+            FieldId(format!("field{i}")),
             random_bytes(rng, bytes_per_field),
         );
         acc

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748929857,
-        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1749177458,
-        "narHash": "sha256-9HNq3EHZIvvxXQyEn0sYOywcESF1Xqw2Q8J1ZewcXuk=",
+        "lastModified": 1751423951,
+        "narHash": "sha256-AowKhJGplXRkAngSvb+32598DTiI6LOzhAnzgvbCtYM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d58933b88cef7a05e9677e94352fd6fedba402cd",
+        "rev": "1684ed5b15859b655caf41b467d046e29a994d04",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 profile = "default"
-channel = "1.87.0"
+channel = "1.88.0"
 components = ["rust-src", "rust-analyzer", "llvm-tools"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,15 +439,13 @@ pub(crate) mod tests {
 
         let key = VectorEncryptionKey::derive_from_secret(&secret, &tenant_id, &derivation_path);
 
-        let expected_sha512 = vec![
-            82u8, 186, 45, 83, 222, 56, 178, 42, 61, 227, 197, 219, 58, 108, 227, 124, 186, 43,
+        let expected_sha512 = [82u8, 186, 45, 83, 222, 56, 178, 42, 61, 227, 197, 219, 58, 108, 227, 124, 186, 43,
             149, 126, 147, 7, 251, 173, 250, 201, 142, 180, 213, 120, 13, 80, 15, 151, 154, 116,
             33, 229, 191, 200, 97, 74, 54, 48, 196, 84, 213, 202, 84, 12, 202, 225, 20, 18, 2, 102,
-            76, 165, 48, 52, 134, 76, 87, 250,
-        ];
+            76, 165, 48, 52, 134, 76, 87, 250];
 
         let expected_scaling_factor: [u8; 4] = std::iter::once(0u8)
-            .chain(expected_sha512[0..3].into_iter().cloned())
+            .chain(expected_sha512[0..3].iter().cloned())
             .collect_vec()
             .try_into()
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,10 +439,12 @@ pub(crate) mod tests {
 
         let key = VectorEncryptionKey::derive_from_secret(&secret, &tenant_id, &derivation_path);
 
-        let expected_sha512 = [82u8, 186, 45, 83, 222, 56, 178, 42, 61, 227, 197, 219, 58, 108, 227, 124, 186, 43,
+        let expected_sha512 = [
+            82u8, 186, 45, 83, 222, 56, 178, 42, 61, 227, 197, 219, 58, 108, 227, 124, 186, 43,
             149, 126, 147, 7, 251, 173, 250, 201, 142, 180, 213, 120, 13, 80, 15, 151, 154, 116,
             33, 229, 191, 200, 97, 74, 54, 48, 196, 84, 213, 202, 84, 12, 202, 225, 20, 18, 2, 102,
-            76, 165, 48, 52, 134, 76, 87, 250];
+            76, 165, 48, 52, 134, 76, 87, 250,
+        ];
 
         let expected_scaling_factor: [u8; 4] = std::iter::once(0u8)
             .chain(expected_sha512[0..3].iter().cloned())

--- a/src/saas_shield/mod.rs
+++ b/src/saas_shield/mod.rs
@@ -61,7 +61,7 @@ pub enum AdminEvent {
 
 impl Display for AdminEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let formatted = format!("ADMIN_{:?}", self).to_case(convert_case::Case::UpperSnake);
+        let formatted = format!("ADMIN_{self:?}").to_case(convert_case::Case::UpperSnake);
         write!(f, "{formatted}")
     }
 }
@@ -89,7 +89,7 @@ pub enum UserEvent {
 
 impl Display for UserEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let formatted = format!("USER_{:?}", self).to_case(convert_case::Case::UpperSnake);
+        let formatted = format!("USER_{self:?}").to_case(convert_case::Case::UpperSnake);
         write!(f, "{formatted}")
     }
 }
@@ -108,7 +108,7 @@ pub enum DataEvent {
 
 impl Display for DataEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let formatted = format!("DATA_{:?}", self).to_case(convert_case::Case::UpperSnake);
+        let formatted = format!("DATA_{self:?}").to_case(convert_case::Case::UpperSnake);
         write!(f, "{formatted}")
     }
 }
@@ -121,7 +121,7 @@ pub enum PeriodicEvent {
 
 impl Display for PeriodicEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let formatted = format!("PERIODIC_{:?}", self).to_case(convert_case::Case::UpperSnake);
+        let formatted = format!("PERIODIC_{self:?}").to_case(convert_case::Case::UpperSnake);
         write!(f, "{formatted}")
     }
 }

--- a/src/tenant_security_client/request.rs
+++ b/src/tenant_security_client/request.rs
@@ -372,7 +372,9 @@ pub(crate) mod tests {
             encrypted_document_keys: HashMap<&str, Base64>,
             _metadata: &RequestMetadata,
         ) -> Result<BatchUnwrapKeyResponse, AlloyError> {
-            let keys = encrypted_document_keys.into_keys().map(|key| {
+            let keys = encrypted_document_keys
+                .into_keys()
+                .map(|key| {
                     (
                         key.to_string(),
                         UnwrapKeyResponse {

--- a/src/tenant_security_client/request.rs
+++ b/src/tenant_security_client/request.rs
@@ -372,9 +372,7 @@ pub(crate) mod tests {
             encrypted_document_keys: HashMap<&str, Base64>,
             _metadata: &RequestMetadata,
         ) -> Result<BatchUnwrapKeyResponse, AlloyError> {
-            let keys = encrypted_document_keys
-                .into_iter()
-                .map(|(key, _)| {
+            let keys = encrypted_document_keys.into_keys().map(|key| {
                     (
                         key.to_string(),
                         UnwrapKeyResponse {

--- a/src/tenant_security_client/rest.rs
+++ b/src/tenant_security_client/rest.rs
@@ -85,9 +85,7 @@ impl TspErrorResponse {
     pub fn try_from_value(value: Value, status: u16) -> Result<Self, AlloyError> {
         serde_json::from_value::<TspErrorResponse>(value.clone()).map_err(|_| {
             AlloyError::RequestError {
-                msg: format!(
-                    "TSP gave an invalid response: `{value}`. Status: {status}"
-                ),
+                msg: format!("TSP gave an invalid response: `{value}`. Status: {status}"),
             }
         })
     }

--- a/src/tenant_security_client/rest.rs
+++ b/src/tenant_security_client/rest.rs
@@ -86,8 +86,7 @@ impl TspErrorResponse {
         serde_json::from_value::<TspErrorResponse>(value.clone()).map_err(|_| {
             AlloyError::RequestError {
                 msg: format!(
-                    "TSP gave an invalid response: `{}`. Status: {}",
-                    value, status
+                    "TSP gave an invalid response: `{value}`. Status: {status}"
                 ),
             }
         })

--- a/src/util.rs
+++ b/src/util.rs
@@ -233,7 +233,7 @@ pub(crate) mod tests {
     #[test]
     fn test_hash_empty_key() {
         assert_eq!(
-            hash256(&Bytes::default(), &[1u8]).to_vec(),
+            hash256(Bytes::default(), [1u8]).to_vec(),
             vec![
                 61, 122, 251, 102, 49, 36, 236, 191, 44, 149, 63, 134, 61, 79, 200, 121, 110, 235,
                 45, 55, 43, 100, 170, 213, 134, 151, 236, 82, 100, 100, 156, 219
@@ -253,7 +253,7 @@ pub(crate) mod tests {
             };
             let key = VectorEncryptionKey {
                 scaling_factor: ScalingFactor(f32_scaling_factor),
-                key: EncryptionKey(key.to_vec().into()),
+                key: EncryptionKey(key.to_vec()),
             };
 
             let first_hash = compute_auth_hash(&key, &1.2f32, iv, arb_msg.iter());
@@ -274,7 +274,7 @@ pub(crate) mod tests {
                 // have a full 4 byte input.
                 // Note that this test is different because it's using 2 random bytes as the padding
                 // here showing that it's not relevant what the padding was, just that it's present.
-                let prefix_padded = [&prefix_bytes[..], &arb_msg[..]].concat();
+                let prefix_padded = [prefix_bytes, &arb_msg[..]].concat();
                 let mut starting = ascii85::encode(prefix_padded.as_slice());
                 // drop the last 2 chars as they're the padding `~>` in the case of ascii85
                 starting.pop();
@@ -300,7 +300,7 @@ pub(crate) mod tests {
                 // so that the algorithm produces the correct character in the 2nd position.
                 // This is due to the way 85 bit encodings change the last character if you don't
                 // have a full 4 byte input.
-                let prefix_padded = [&prefix_bytes[..], &[0,0]].concat();
+                let prefix_padded = [prefix_bytes, &[0,0]].concat();
                 let mut starting = z85::encode(prefix_padded.as_slice());
                 // drop the last 3 characters of the produced string
                 // as they could be affected by the random bytes
@@ -323,7 +323,7 @@ pub(crate) mod tests {
                 // so that the algorithm produces the correct character in the 2nd position.
                 // This is due to the way 85 bit encodings change the last character if you don't
                 // have a full 4 byte input.
-                let prefix_padded = [&prefix_bytes[..], &[0, 0]].concat();
+                let prefix_padded = [prefix_bytes, &[0, 0]].concat();
                 let mut starting = base85::encode(prefix_padded.as_slice());
                 // drop the last 3 characters of the produced string
                 // as they could be affected by the random bytes
@@ -392,7 +392,7 @@ pub(crate) mod tests {
             let prefix = encode_prefix(prefix_bytes.as_slice());
             let full_vec = prefix_bytes
                 .into_iter()
-                .chain(arb_msg.to_vec().into_iter())
+                .chain(arb_msg.iter().copied())
                 .collect_vec();
             // String encoded prefix + arbitrary bytes.
             let encoded_string = encode_message(full_vec.as_slice());

--- a/src/vector/crypto.rs
+++ b/src/vector/crypto.rs
@@ -132,7 +132,7 @@ fn generate_normalized_vector(
     calculate_normalized_vector(multivariate_normal_sample, uniform_point_in_ball)
 }
 
-pub(crate) fn encrypt<R: RngCore + CryptoRng>(
+pub(crate) fn encrypt<R: RngCore + CryptoRng + Send + Sync>(
     key: &VectorEncryptionKey, // K + s in the paper, key and scaling factor
     approximation_factor: f32,
     message: Array1<f32>, // m in the paper, vector
@@ -286,13 +286,10 @@ pub(crate) mod tests {
         let result = encrypt(
             &VectorEncryptionKey {
                 scaling_factor: ScalingFactor(1235.),
-                key: EncryptionKey(
-                    vec![
-                        69, 96, 99, 158, 198, 112, 183, 161, 125, 73, 43, 39, 62, 7, 123, 10, 150,
-                        190, 245, 139, 167, 118, 7, 121, 229, 68, 84, 110, 0, 14, 254, 200,
-                    ]
-                    .into(),
-                ),
+                key: EncryptionKey(vec![
+                    69, 96, 99, 158, 198, 112, 183, 161, 125, 73, 43, 39, 62, 7, 123, 10, 150, 190,
+                    245, 139, 167, 118, 7, 121, 229, 68, 84, 110, 0, 14, 254, 200,
+                ]),
             },
             NEW_APPROX_FACTOR,
             vec![1., 2., 3., 4., 5.].into(),
@@ -323,13 +320,10 @@ pub(crate) mod tests {
         let result = encrypt(
             &VectorEncryptionKey {
                 scaling_factor: ScalingFactor(1235.),
-                key: EncryptionKey(
-                    vec![
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0,
-                    ]
-                    .into(),
-                ),
+                key: EncryptionKey(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0,
+                ]),
             },
             ORIGINAL_APPROX_FACTOR,
             vec![1., 2., 3., 4., 5.].into(),
@@ -360,13 +354,10 @@ pub(crate) mod tests {
         let result = encrypt(
             &VectorEncryptionKey {
                 scaling_factor: ScalingFactor(1235.),
-                key: EncryptionKey(
-                    vec![
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0,
-                    ]
-                    .into(),
-                ),
+                key: EncryptionKey(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0,
+                ]),
             },
             ORIGINAL_APPROX_FACTOR,
             vec![].into(),
@@ -386,13 +377,10 @@ pub(crate) mod tests {
         encrypt(
             &VectorEncryptionKey {
                 scaling_factor: ScalingFactor(s),
-                key: EncryptionKey(
-                    vec![
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0,
-                    ]
-                    .into(),
-                ),
+                key: EncryptionKey(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0,
+                ]),
             },
             ORIGINAL_APPROX_FACTOR,
             vec![].into(),
@@ -420,13 +408,10 @@ pub(crate) mod tests {
         let result = decrypt(
             &VectorEncryptionKey {
                 scaling_factor: ScalingFactor(1235.),
-                key: EncryptionKey(
-                    vec![
-                        69, 96, 99, 158, 198, 112, 183, 161, 125, 73, 43, 39, 62, 7, 123, 10, 150,
-                        190, 245, 139, 167, 118, 7, 121, 229, 68, 84, 110, 0, 14, 254, 200,
-                    ]
-                    .into(),
-                ),
+                key: EncryptionKey(vec![
+                    69, 96, 99, 158, 198, 112, 183, 161, 125, 73, 43, 39, 62, 7, 123, 10, 150, 190,
+                    245, 139, 167, 118, 7, 121, 229, 68, 84, 110, 0, 14, 254, 200,
+                ]),
             },
             ORIGINAL_APPROX_FACTOR,
             EncryptResult {
@@ -452,13 +437,10 @@ pub(crate) mod tests {
         let result = decrypt(
             &VectorEncryptionKey {
                 scaling_factor: ScalingFactor(1235.),
-                key: EncryptionKey(
-                    vec![
-                        69, 96, 99, 158, 198, 112, 183, 161, 125, 73, 43, 39, 62, 7, 123, 10, 150,
-                        190, 245, 139, 167, 118, 7, 121, 229, 68, 84, 110, 0, 14, 254, 200,
-                    ]
-                    .into(),
-                ),
+                key: EncryptionKey(vec![
+                    69, 96, 99, 158, 198, 112, 183, 161, 125, 73, 43, 39, 62, 7, 123, 10, 150, 190,
+                    245, 139, 167, 118, 7, 121, 229, 68, 84, 110, 0, 14, 254, 200,
+                ]),
             },
             NEW_APPROX_FACTOR,
             EncryptResult {
@@ -479,13 +461,10 @@ pub(crate) mod tests {
         decrypt(
             &VectorEncryptionKey {
                 scaling_factor: ScalingFactor(s),
-                key: EncryptionKey(
-                    vec![
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0,
-                    ]
-                    .into(),
-                ),
+                key: EncryptionKey(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0,
+                ]),
             },
             ORIGINAL_APPROX_FACTOR,
             EncryptResult {
@@ -515,21 +494,18 @@ pub(crate) mod tests {
     fn roundtrip_small_value() {
         let key = VectorEncryptionKey {
             scaling_factor: ScalingFactor(1.),
-            key: EncryptionKey(
-                vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0,
-                ]
-                .into(),
-            ),
+            key: EncryptionKey(vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ]),
         };
         // let mut prf_rng = rand_chacha::ChaCha20Rng::seed_from_u64(1u64);
-        let message: Array1<f32> = vec![-6.593513538421856e-163].into();
+        let message: Array1<f32> = vec![-0.0].into();
         let encrypt_result = encrypt(
             &key,
             ORIGINAL_APPROX_FACTOR,
             message.clone(),
-            Arc::new(Mutex::new(rand::thread_rng())),
+            new_rng(),
             true,
         )
         .unwrap();
@@ -543,11 +519,11 @@ pub(crate) mod tests {
         fn roundtrip(arb_msg: Vec<u16>, key: [u8; 32], scaling_factor in 1..16777215) {
             let key = VectorEncryptionKey {
                 scaling_factor: ScalingFactor(scaling_factor as f32),
-                key: EncryptionKey(key.to_vec().into()),
+                key: EncryptionKey(key.to_vec()),
             };
             let approximation_factor = 5.;
             let message: Array1<f32> = arb_msg.into_iter().map(|u| u as f32).collect();
-            let encrypt_result = encrypt(&key, approximation_factor, message.clone(),  Arc::new(Mutex::new(rand::thread_rng())), true).unwrap();
+            let encrypt_result = encrypt(&key, approximation_factor, message.clone(),  new_rng(), true).unwrap();
             let decrypt_result = decrypt(&key, approximation_factor, encrypt_result, true).unwrap();
             assert_ulps_eq!(message.as_slice().unwrap(), decrypt_result.as_slice().unwrap());
         }
@@ -556,11 +532,11 @@ pub(crate) mod tests {
         fn roundtrip_no_scaling(arb_msg: Vec<u16>, key: [u8; 32], scaling_factor in 1..16777215) {
             let key = VectorEncryptionKey {
                 scaling_factor: ScalingFactor(scaling_factor as f32),
-                key: EncryptionKey(key.to_vec().into()),
+                key: EncryptionKey(key.to_vec()),
             };
             let approximation_factor = 5.;
             let message: Array1<f32> = arb_msg.into_iter().map(|u| u as f32).collect();
-            let encrypt_result = encrypt(&key, approximation_factor, message.clone(),  Arc::new(Mutex::new(rand::thread_rng())), false).unwrap();
+            let encrypt_result = encrypt(&key, approximation_factor, message.clone(),  new_rng(), false).unwrap();
             let decrypt_result = decrypt(&key, approximation_factor, encrypt_result, false).unwrap();
             assert_ulps_eq!(message.as_slice().unwrap(), decrypt_result.as_slice().unwrap());
         }
@@ -569,13 +545,10 @@ pub(crate) mod tests {
     fn get_key() -> VectorEncryptionKey {
         VectorEncryptionKey {
             scaling_factor: ScalingFactor(1235.),
-            key: EncryptionKey(
-                vec![
-                    69, 96, 99, 158, 198, 112, 183, 161, 125, 73, 43, 39, 62, 7, 123, 10, 150, 190,
-                    245, 139, 167, 118, 7, 121, 229, 68, 84, 110, 0, 14, 254, 200,
-                ]
-                .into(),
-            ),
+            key: EncryptionKey(vec![
+                69, 96, 99, 158, 198, 112, 183, 161, 125, 73, 43, 39, 62, 7, 123, 10, 150, 190,
+                245, 139, 167, 118, 7, 121, 229, 68, 84, 110, 0, 14, 254, 200,
+            ]),
         }
     }
     fn shuffle_with_static_key<A>(values: Array1<A>) -> Array1<A> {
@@ -637,7 +610,7 @@ pub(crate) mod tests {
         );
 
         // Shuffle twice and unshuffle twice
-        let one: Array1<_> = (1..100).into_iter().collect();
+        let one: Array1<_> = (1..100).collect();
         assert_eq!(
             unshuffle_with_static_key(unshuffle_with_static_key(shuffle_with_static_key(
                 shuffle_with_static_key(one.clone())
@@ -645,5 +618,13 @@ pub(crate) mod tests {
             .to_vec(),
             one.to_vec()
         );
+    }
+    fn new_rng() -> Arc<Mutex<ChaCha20Rng>> {
+        let mut entropy_source = rand::rngs::OsRng;
+        let rng =
+            ChaCha20Rng::from_rng(&mut entropy_source).expect("Failed to seed RNG from OsRng");
+
+        // Wrap in Arc<Mutex> to make it Send + Sync
+        Arc::new(Mutex::new(rng))
     }
 }

--- a/src/vector/crypto.rs
+++ b/src/vector/crypto.rs
@@ -29,7 +29,7 @@ pub(crate) enum EncryptError {
 impl Display for EncryptError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EncryptError::InvalidKey(msg) => write!(f, "{}", msg),
+            EncryptError::InvalidKey(msg) => write!(f, "{msg}"),
             EncryptError::OverflowError => {
                 write!(f, "Embedding or approximation factor too large.")
             }
@@ -48,7 +48,7 @@ pub(crate) enum DecryptError {
 impl Display for DecryptError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DecryptError::InvalidKey(msg) => write!(f, "{}", msg),
+            DecryptError::InvalidKey(msg) => write!(f, "{msg}"),
             DecryptError::InvalidAuthHash => write!(f, "Auth Hash verification failed."),
         }
     }
@@ -393,14 +393,14 @@ pub(crate) mod tests {
     fn encrypt_errors_zero_scaling_factor() {
         let result = encrypt_with_scaling_factor(0.0).unwrap_err();
         assert!(matches!(result, EncryptError::InvalidKey(_)));
-        assert!(format!("{:?}", result).contains("Scaling factor"));
+        assert!(format!("{result:?}").contains("Scaling factor"));
     }
 
     #[test]
     fn encrypt_errors_neg_zero_scaling_factor() {
         let result = encrypt_with_scaling_factor(0.0).unwrap_err();
         assert!(matches!(result, EncryptError::InvalidKey(_)));
-        assert!(format!("{:?}", result).contains("Scaling factor"));
+        assert!(format!("{result:?}").contains("Scaling factor"));
     }
 
     #[test]
@@ -480,13 +480,13 @@ pub(crate) mod tests {
     fn decrypt_errors_zero_scaling_factor() {
         let result = decrypt_with_scaling_factor(0.0).unwrap_err();
         assert!(matches!(result, DecryptError::InvalidKey(_)));
-        assert!(format!("{:?}", result).contains("Scaling factor"));
+        assert!(format!("{result:?}").contains("Scaling factor"));
     }
     #[test]
     fn decrypt_errors_neg_zero_scaling_factor() {
         let result = decrypt_with_scaling_factor(-0.0).unwrap_err();
         assert!(matches!(result, DecryptError::InvalidKey(_)));
-        assert!(format!("{:?}", result).contains("Scaling factor"));
+        assert!(format!("{result:?}").contains("Scaling factor"));
     }
 
     #[ignore]

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -213,7 +213,7 @@ pub(crate) fn get_iv_and_auth_hash(b: &[u8]) -> Result<([u8; 12], AuthHash), All
     ))
 }
 
-pub(crate) fn encrypt_internal<R: RngCore + CryptoRng>(
+pub(crate) fn encrypt_internal<R: RngCore + CryptoRng + Send + Sync>(
     approximation_factor: f32,
     key: &VectorEncryptionKey,
     key_id: KeyId,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -59,7 +59,7 @@ pub(crate) fn get_dynamic_library_paths() -> Result<Vec<PathBuf>, Box<dyn Error>
     .map(|dir_entry| dir_entry.path())
     // Filter out all paths with extensions other than `so` or `dylib`
     .filter_map(|path| {
-        if path.extension().map_or(false, |ext| {
+        if path.extension().is_some_and(|ext| {
             (ext == "dylib" || ext == "so")
                 && path
                     .file_name()

--- a/tests/foreign_tests_java.rs
+++ b/tests/foreign_tests_java.rs
@@ -27,7 +27,7 @@ mod test {
                 main_resources_path.join(library_file.file_name().unwrap()),
             )?;
         }
-        println!("{:?}", main_src_path);
+        println!("{main_src_path:?}");
         // generate the bindings to go with the just compiled binary
         generate_bindings(
             dynamic_library_paths[0].clone(),

--- a/tests/foreign_tests_kotlin.rs
+++ b/tests/foreign_tests_kotlin.rs
@@ -26,7 +26,7 @@ mod test {
                 main_resources_path.join(library_file.file_name().unwrap()),
             )?;
         }
-        println!("{:?}", main_src_path);
+        println!("{main_src_path:?}");
         // generate the bindings to go with the just compiled binary
         generate_bindings(
             dynamic_library_paths[0].clone(),


### PR DESCRIPTION
```
colt@breq:~/src/icl/ironcore-alloy/ > cargo update
    Updating crates.io index
     Locking 5 packages to latest Rust 1.85.0 compatible versions
    Updating crunchy v0.2.3 -> v0.2.4
    Updating indexmap v2.9.0 -> v2.10.0
      Adding io-uring v0.7.8
    Updating reqwest v0.12.20 -> v0.12.22
    Updating tokio v1.45.1 -> v1.46.0
note: pass `--verbose` to see 4 unchanged dependencies behind latest
```