### PR TITLE
Fix pinecone jupyter notebook

### DIFF
--- a/example-integrations/pinecone/pinecone-semantic-search.ipynb
+++ b/example-integrations/pinecone/pinecone-semantic-search.ipynb
@@ -6,7 +6,7 @@
         "id": "k7Lc9I6taO3k"
       },
       "source": [
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ironcorelabs/ironcore-alloy/blob/main/examples/python/standalone/pinecone-semantic-search-encrypted.ipynb) [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/ironcorelabs/ironcore-alloy/blob/main/examples/python/standalone/pinecone-semantic-search-encrypted.ipynb)\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ironcorelabs/ironcore-alloy/blob/main/example-integrations/pinecone/pinecone-semantic-search.ipynb) [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/ironcorelabs/ironcore-alloy/blob/main/example-integrations/pinecone/pinecone-semantic-search.ipynb)\n",
         "\n",
         "# Using IronCore Labs Cloaked AI with Pinecone\n",
         "\n",


### PR DESCRIPTION
I navigated to the correct URL for the notebook (https://colab.research.google.com/github/IronCoreLabs/ironcore-alloy/blob/main/example-integrations/pinecone/pinecone-semantic-search.ipynb) and re-downloaded the `.ipynb` file. I'm not sure why the `state` got messed up, but it seems to be working now. I also fixed the links at the top of the notebook.