### PR TITLE
Don't build the explicit bindgen binary parts for doc build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.1
+
+- Fix to Rust doc.rs build.
+
 ## 0.15.0
 
 - Dependency updates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["cryptography"]
 keywords = ["cryptography", "saas-shield", "ALE", "cloaked-ai"]
 rust-version = "1.85.0"
 
+[package.metadata.docs.rs]
+# Disable default features to exclude heavy uniffi-bindgen deps that cause OOM
+no-default-features = true
+
 # This is needed to allow extra options to be passed to criterion
 # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
@@ -32,7 +36,9 @@ path = "uniffi-bindgen-java.rs"
 bench = false
 
 [features]
+default = ["bindgen"]
 integration_tests = []
+bindgen = ["uniffi/cli", "dep:uniffi-bindgen-java"]
 
 [dependencies]
 aes-gcm = "0.10"
@@ -61,8 +67,8 @@ ring = "0.17"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.149", features = ["float_roundtrip"] }
 thiserror = "2.0.18"
-uniffi = { version = "0.31.0", features = ["tokio", "cli"] }
-uniffi-bindgen-java = "0.4.1"
+uniffi = { version = "0.31.0", features = ["tokio"] }
+uniffi-bindgen-java = { version = "0.4.1", optional = true }
 z85 = "3.0.7"
 
 [dev-dependencies]


### PR DESCRIPTION
They're not needed and inflate the memory required beyond the rustdocs limit. I tested locally with a script that watched memory usage and it never went over 2GB this way, which is under the 6GB on docs.rs.

This fixes https://docs.rs/crate/ironcore-alloy/latest/builds/3140949