### PR TITLE
Fixes the integration test that sends log event nowhere

### DIFF
--- a/tests/demo-tsp.conf
+++ b/tests/demo-tsp.conf
@@ -6,3 +6,7 @@ SERVICE_SEGMENT_ID=698
 API_KEY=0WUaXesNgbTAuLwn
 IRONCORE_ENV=stage
 RUST_LOG=info
+# Nothing listens here. Event delivery is off unless a URL is set, and off means the TSP rejects
+# security events, failing the log_security_event tests; delivery is async so they never need a
+# live Logdriver.
+TSP_LOGDRIVER_URL=http://127.0.0.1:9999


### PR DESCRIPTION
by enabling logdriver that goes to nothing. The new TSP/TSL uses a logdriver address on the TSP, if it's not present Logdriver is disabled. The integration tests don't actually need a TSL to send to, but they want to test that they queue a message, so we enable a dummy localhost address to "enable" logdriver that allows for queuing.