### PR TITLE
Switch to trusted publishing for rust releases

### DIFF
--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -125,7 +125,7 @@ jobs:
         working-directory: python/ironcore-alloy/ironcore_alloy
 
   rust-release:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-release.yaml@rust-release-v1
+    uses: IronCoreLabs/workflows/.github/workflows/rust-release.yaml@rust-release-v2
     secrets: inherit
 
   build-docs:


### PR DESCRIPTION
No dry-run here because we'd need a bunch of conditional junk with all the different langs, we've got a good idea from elsewhere if it works and a failure isn't accidentally releasing something.