### PR TITLE
Pin IronCore workflow tags to their dotted names

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   bump:
-    uses: IronCoreLabs/workflows/.github/workflows/bump-version.yaml@bump-version-v1
+    uses: IronCoreLabs/workflows/.github/workflows/bump-version.yaml@bump-version-v1.0.0
     with:
       version: ${{ inputs.version }}
       release_mode: prerelease

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,7 +17,7 @@ jobs:
           distribution: "temurin"
           java-version: "25"
       - name: Start the TSP
-        uses: IronCoreLabs/workflows/.github/actions/start-tsp@start-tsp-v1
+        uses: IronCoreLabs/workflows/.github/actions/start-tsp@start-tsp-v1.0.0
         with:
           gcloud-auth: ${{ secrets.GCLOUD_AUTH }}
           env-file-path: tests/demo-tsp.conf

--- a/.github/workflows/rust-cargo-update.yaml
+++ b/.github/workflows/rust-cargo-update.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   rust-cargo-update:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-cargo-update.yaml@rust-cargo-update-v1
+    uses: IronCoreLabs/workflows/.github/workflows/rust-cargo-update.yaml@rust-cargo-update-v1.0.0
     with:
       reviewer: ${{inputs.reviewer}}
     secrets: inherit

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   rust-ci:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-ci.yaml@rust-ci-v2
+    uses: IronCoreLabs/workflows/.github/workflows/rust-ci.yaml@rust-ci-v2.0.0
     with:
       run_clippy: true
       minimum_coverage: "50"

--- a/.github/workflows/rust-daily.yaml
+++ b/.github/workflows/rust-daily.yaml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   rust-daily:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-daily.yaml@rust-daily-v1
+    uses: IronCoreLabs/workflows/.github/workflows/rust-daily.yaml@rust-daily-v1.0.0
     secrets: inherit

--- a/.github/workflows/sdk-ci.yaml
+++ b/.github/workflows/sdk-ci.yaml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   generate-cdylibs:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-artifact.yaml@rust-artifact-v0
+    uses: IronCoreLabs/workflows/.github/workflows/rust-artifact.yaml@rust-artifact-v0.0.0
     with:
       # This should stay in sync with the `runs-on` from the other jobs in this file
       os_matrix: "[\"ubuntu-24.04\", \"ubuntu-24.04-arm\", \"macos-15-intel\",

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   generate-cdylibs:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-artifact.yaml@rust-artifact-v0
+    uses: IronCoreLabs/workflows/.github/workflows/rust-artifact.yaml@rust-artifact-v0.0.0
     with:
       os_matrix: '["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15-intel", "macos-15"]'
       build_profile: "release"
@@ -125,7 +125,7 @@ jobs:
         working-directory: python/ironcore-alloy/ironcore_alloy
 
   rust-release:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-release.yaml@rust-release-v2
+    uses: IronCoreLabs/workflows/.github/workflows/rust-release.yaml@rust-release-v2.0.0
     secrets: inherit
 
   build-docs:


### PR DESCRIPTION
`IronCoreLabs/workflows` now publishes its floating tags under dotted names:
`rust-ci-v3.0.0` instead of `rust-ci-v3`. Same commit, same auto-updating
behavior — but Dependabot can parse the dotted form, so this repo will get a PR
when a workflow's next major ships.

The undotted tags are frozen and no longer move, so a repo left on them stops
receiving workflow updates entirely.

See https://github.com/IronCoreLabs/workflows/blob/main/RELEASING.md
