### PR TITLE
Use start-tsp v2, which authenticates to GCP with Workload Identity Federation

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,6 +10,10 @@ on:
 jobs:
   integration_test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6
@@ -17,9 +21,8 @@ jobs:
           distribution: "temurin"
           java-version: "25"
       - name: Start the TSP
-        uses: IronCoreLabs/workflows/.github/actions/start-tsp@start-tsp-v1.0.0
+        uses: IronCoreLabs/workflows/.github/actions/start-tsp@start-tsp-v2.0.0
         with:
-          gcloud-auth: ${{ secrets.GCLOUD_AUTH }}
           env-file-path: tests/demo-tsp.conf
           tsp-port: "32804"
       - name: Install hatch


### PR DESCRIPTION
The `GCLOUD_AUTH` service account key is no longer passed in. The job declares `id-token: write` for the OIDC token and `pull-requests: write` for the action's `TSP_IMAGE` comment reactions; an explicit `permissions` block zeroes unlisted scopes, and no other step in the job needs more.

Depends on IronCoreLabs/workflows#177 (merged; `start-tsp-v2.0.0` exists). Once every consumer is merged, the `GCLOUD_AUTH` org secret and the `depot-ci` user-managed key can be deleted.

Verified: `actionlint` clean on the changed file. This PR's own CI run is the end-to-end proof.